### PR TITLE
Update registry according to lifecycle design

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ The `oci-devfile-registry-metadata` container is a sidecar deployed alongside th
 
 ### OpenShift
 
-1) `cd deploy/openshift`
-2) Set the value of `$HOST` in `route.yaml` to your routing suffix (such as apps.devcluster.example.com)
-3) Run `oc apply -f registry.yaml`
-4) Run `oc apply -f route.yaml`
+1) Run `oc apply -f deploy/openshift/`
+
+### Kubernetes
+
+1) Set the value of `$HOST` in `deploy/kubernetes/ingress.yaml` to your ingress domain (such as 192.168.1.1.nip.io)
+2) Run `kubectl apply -f deploy/kubernetes/`

--- a/deploy/kubernetes/ingress.yaml
+++ b/deploy/kubernetes/ingress.yaml
@@ -10,7 +10,7 @@ spec:
       - backend:
           serviceName: devfile-registry
           servicePort: 8080
-        path: /devfiles
+        path: /
         pathType: ImplementationSpecific
 ---
 apiVersion: extensions/v1beta1

--- a/deploy/kubernetes/ingress.yaml
+++ b/deploy/kubernetes/ingress.yaml
@@ -1,25 +1,24 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: devfile-registry-ingress
+  name: devfile-catalog
 spec:
   rules:
-  - host: $HOST
+  - host: devfile-registry.$HOST
     http:
       paths:
       - backend:
           serviceName: devfile-registry
           servicePort: 8080
         path: /
-        pathType: ImplementationSpecific
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: registry-ingress
+  name: registry
 spec:
   rules:
-  - host: $HOST
+  - host: registry.$HOST
     http:
       paths:
       - backend:

--- a/deploy/kubernetes/registry.yaml
+++ b/deploy/kubernetes/registry.yaml
@@ -15,18 +15,48 @@ spec:
         app: devfile-registry
     spec:
       volumes:
-        - name: registry-storage
-          persistentVolumeClaim:
-            claimName: registry-storage-claim
+      - name: devfile-registry-storage
+        persistentVolumeClaim:
+          claimName: devfile-registry-storage
       containers:
       - name: devfile-registry-metadata
         image: docker.io/johncollier/oci-devfile-registry-metadata:latest
         ports:
         - containerPort: 8080
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /devfiles/index.json
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /devfiles/index.json
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+
       - name: devfile-registry
         image: registry:latest
         ports:
         - containerPort: 5000
+        volumeMounts:
+        - mountPath: "/var/lib/registry"
+          name: devfile-registry-storage
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
 ---
 apiVersion: v1
 kind: Service
@@ -46,10 +76,12 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: registry-storage-claim
+  name: devfile-registry-storage
+  labels:
+    app: devfile-registry
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 3Gi
+      storage: 10Gi

--- a/deploy/kubernetes/registry.yaml
+++ b/deploy/kubernetes/registry.yaml
@@ -20,16 +20,16 @@ spec:
           claimName: devfile-registry-storage
       containers:
       - name: devfile-registry-metadata
-        image: docker.io/johncollier/oci-devfile-registry-metadata:latest
+        image: quay.io/devfile/metadata-server:latest
         ports:
         - containerPort: 8080
         resources:
           requests:
             memory: "64Mi"
-            cpu: "250m"
+            cpu: "100m"
           limits:
             memory: "128Mi"
-            cpu: "500m"
+            cpu: "250m"
         livenessProbe:
           httpGet:
             path: /devfiles/index.json
@@ -53,7 +53,7 @@ spec:
         resources:
           requests:
             memory: "64Mi"
-            cpu: "250m"
+            cpu: "100m"
           limits:
             memory: "256Mi"
             cpu: "500m"

--- a/deploy/openshift/registry.yaml
+++ b/deploy/openshift/registry.yaml
@@ -14,15 +14,49 @@ spec:
       labels:
         app: devfile-registry
     spec:
+      volumes:
+      - name: devfile-registry-storage
+        persistentVolumeClaim:
+          claimName: devfile-registry-storage
       containers:
       - name: devfile-registry-metadata
         image: docker.io/johncollier/oci-devfile-registry-metadata:latest
         ports:
         - containerPort: 8080
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"
+        livenessProbe:
+          httpGet:
+            path: /devfiles/index.json
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /devfiles/index.json
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 3
+
       - name: devfile-registry
         image: registry:latest
         ports:
         - containerPort: 5000
+        volumeMounts:
+        - mountPath: "/var/lib/registry"
+          name: devfile-registry-storage
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "256Mi"
+            cpu: "500m"
 ---
 apiVersion: v1
 kind: Service
@@ -38,3 +72,16 @@ spec:
       name: devfile-registry
   selector:
     app: devfile-registry
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: devfile-registry-storage
+  labels:
+    app: devfile-registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/deploy/openshift/registry.yaml
+++ b/deploy/openshift/registry.yaml
@@ -20,16 +20,16 @@ spec:
           claimName: devfile-registry-storage
       containers:
       - name: devfile-registry-metadata
-        image: docker.io/johncollier/oci-devfile-registry-metadata:latest
+        image: quay.io/devfile/metadata-server:latest
         ports:
         - containerPort: 8080
         resources:
           requests:
             memory: "64Mi"
-            cpu: "250m"
+            cpu: "100m"
           limits:
             memory: "128Mi"
-            cpu: "500m"
+            cpu: "250m"
         livenessProbe:
           httpGet:
             path: /devfiles/index.json
@@ -53,7 +53,7 @@ spec:
         resources:
           requests:
             memory: "64Mi"
-            cpu: "250m"
+            cpu: "100m"
           limits:
             memory: "256Mi"
             cpu: "500m"

--- a/deploy/openshift/route.yaml
+++ b/deploy/openshift/route.yaml
@@ -3,7 +3,6 @@ apiVersion: route.openshift.io/v1
 metadata:
   name: registry
 spec:
-  host: $HOST
   to:
     kind: Service
     name: devfile-registry
@@ -17,8 +16,6 @@ apiVersion: route.openshift.io/v1
 metadata:
   name: devfile-registry
 spec:
-  host: $HOST
-  path: /devfiles
   to:
     kind: Service
     name: devfile-registry

--- a/oci-devfile-registry-metadata/Dockerfile
+++ b/oci-devfile-registry-metadata/Dockerfile
@@ -34,7 +34,7 @@ COPY entrypoint.sh /scripts/entrypoint.sh
 
 # Git clone the devfiles
 # ToDo: Switch to github.com/devfile/catalog/
-RUN git clone https://github.com/odo-devfiles/registry /registry
+RUN git clone https://github.com/devfile/registry /registry
 COPY --from=build /tools/index-generator /registry/index-generator
 RUN chgrp -R 0 /registry && \
     chmod -R g=u /registry

--- a/oci-devfile-registry-metadata/Dockerfile
+++ b/oci-devfile-registry-metadata/Dockerfile
@@ -7,7 +7,7 @@ RUN ./build.sh
 FROM docker.io/httpd:2.4.43-alpine AS registry
 
 # Install and configure dependencies
-RUN apk add --no-cache bash git && \
+RUN apk add --no-cache bash git curl && \
     # Allow htaccess
     sed -i 's|    AllowOverride None|    AllowOverride All|' /usr/local/apache2/conf/httpd.conf && \
     sed -i 's|Listen 80|Listen 8080|' /usr/local/apache2/conf/httpd.conf && \

--- a/oci-devfile-registry-metadata/entrypoint.sh
+++ b/oci-devfile-registry-metadata/entrypoint.sh
@@ -1,14 +1,14 @@
 #!/bin/sh
 
 ## Simple proof of concept bootstrap script to load devfiles into an oci registry
-DEVFILES=/registry/devfiles
+DEVFILES=/registry/stacks
 
 # Generate the index.json from the devfiles
 cd /registry
-./index-generator ./devfiles /usr/local/apache2/htdocs/devfiles/index.json
+./index-generator $DEVFILES /usr/local/apache2/htdocs/devfiles/index.json
 
 # Push the devfiles to the registry
-cd /registry/devfiles
+cd $DEVFILES
 
 # Wait for the registry to start
 until $(curl --output /dev/null --silent --head --fail http://localhost:5000); do
@@ -31,7 +31,7 @@ do
   echo "Pushing $stackName to $REGISTRY_HOST"
   cd $stackName
   oras push localhost:5000/devfile-catalog/$stackName:latest --manifest-config /dev/null:application/vnd.devfileio.devfile.config.v2+json ./devfile.yaml:application/vnd.devfileio.devfile.layer.v1 --plain-http
-  cd /registry/devfiles
+  cd $DEVFILES
 done
 
 # Launch the server hosting the index.json

--- a/oci-devfile-registry-metadata/entrypoint.sh
+++ b/oci-devfile-registry-metadata/entrypoint.sh
@@ -8,8 +8,14 @@ cd /registry
 ./index-generator ./devfiles /usr/local/apache2/htdocs/devfiles/index.json
 
 # Push the devfiles to the registry
-# ToDo: Cleanup
 cd /registry/devfiles
+
+# Wait for the registry to start
+until $(curl --output /dev/null --silent --head --fail http://localhost:5000); do
+    printf 'Waiting for the registry at localhost:5000 to start\n'
+    sleep 0.5
+done
+
 for devfileDir in "$DEVFILES"/*
 do
   devfile="$devfileDir/devfile.yaml"
@@ -24,7 +30,7 @@ do
   # 5) Do in Golang
   echo "Pushing $stackName to $REGISTRY_HOST"
   cd $stackName
-  oras push devfile-registry:5000/devfile-catalog/$stackName:latest --manifest-config /dev/null:application/vnd.devfileio.devfile.config.v2+json ./devfile.yaml:application/vnd.devfileio.devfile.layer.v1 --plain-http
+  oras push localhost:5000/devfile-catalog/$stackName:latest --manifest-config /dev/null:application/vnd.devfileio.devfile.config.v2+json ./devfile.yaml:application/vnd.devfileio.devfile.layer.v1 --plain-http
   cd /registry/devfiles
 done
 

--- a/oci-devfile-registry-metadata/push.sh
+++ b/oci-devfile-registry-metadata/push.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+IMAGE_TAG=$1
+docker tag devfile-registry-metadata:latest $IMAGE_TAG
+docker push $1


### PR DESCRIPTION
Fixes https://github.com/devfile/api/issues/162

Based on the [OCI registry lifecycle design](https://docs.google.com/document/d/1rQHCp4SWslWWJv5KK3A_iXHvgbqjsuDkSKDD72ifJio/edit?usp=sharing), this PR implements the following related to the registry lifecycle

- Persistent volume for the devfile artifacts, mounted at `/var/lib/registry` on the registry container
- Resource requests and limits for both containers
- Readiness and liveness probes for the metadata container.

Other aspects, such as the registry operator (and any lifecycle components related to the operator), will be handled separately.