### PR TITLE
Change `links` schema

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -38,9 +38,12 @@ func GenerateIndexStruct(registryDirPath string) ([]schema.Schema, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal %s data: %v", metaFilePath, err)
 		}
-		indexComponent.Links = schema.Links{
-			Self: fmt.Sprintf("%s/%s:%s", "devfile-catalog", indexComponent.Name, "latest"),
+
+		if indexComponent.Links == nil {
+			indexComponent.Links = make(map[string]string)
 		}
+		indexComponent.Links["self"] = fmt.Sprintf("%s/%s:%s", "devfile-catalog", indexComponent.Name, "latest")
+
 		index = append(index, indexComponent)
 	}
 

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -46,24 +46,18 @@ description: string - The description of devfile
 tags: string[] - The tags associated to devfile
 projectType: string - The project framework that is used in the devfile
 language: string - The project language that is used in the devfile
-links: object
-    self: string - The link to the devfile image or devfile path
+links: map[string]string - Links related to the devfile
 starterProjects: string[] - The project templates that can be used in the devfile
 */
 
 // Schema is the index file schema
 type Schema struct {
-	Name            string   `yaml:"name,omitempty" json:"name,omitempty"`
-	DisplayName     string   `yaml:"displayName,omitempty" json:"displayName,omitempty"`
-	Description     string   `yaml:"description,omitempty" json:"description,omitempty"`
-	Tags            []string `yaml:"tags,omitempty" json:"tags,omitempty"`
-	ProjectType     string   `yaml:"projectType,omitempty" json:"projectType,omitempty"`
-	Language        string   `yaml:"language,omitempty" json:"language,omitempty"`
-	Links           Links    `yaml:"links,omitempty" json:"links,omitempty"`
-	StarterProjects []string `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
-}
-
-// Links are the links to devfile
-type Links struct {
-	Self string `yaml:"self,omitempty" json:"self,omitempty"`
+	Name            string            `yaml:"name,omitempty" json:"name,omitempty"`
+	DisplayName     string            `yaml:"displayName,omitempty" json:"displayName,omitempty"`
+	Description     string            `yaml:"description,omitempty" json:"description,omitempty"`
+	Tags            []string          `yaml:"tags,omitempty" json:"tags,omitempty"`
+	ProjectType     string            `yaml:"projectType,omitempty" json:"projectType,omitempty"`
+	Language        string            `yaml:"language,omitempty" json:"language,omitempty"`
+	Links           map[string]string `yaml:"links,omitempty" json:"links,omitempty"`
+	StarterProjects []string          `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**Please specify the area for this PR**
Registry index schema

**What does does this PR do / why we need it**:
This PR changes the `links` schema in registry index from custom struct to map.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/185

**PR acceptance criteria**:

- [x] Test (WIP) 

- [x] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
Use the index generator CLI or call the the index generator module function to generate index file.
