### PR TITLE
Make index generator ignore non-directories in registry root directory

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -25,7 +25,7 @@ func GenerateIndexStruct(registryDirPath string) ([]schema.Schema, error) {
 	var index []schema.Schema
 	for _, devfileDir := range registryDir {
 		if !devfileDir.IsDir() {
-			return nil, fmt.Errorf("%s is not a directory", filepath.Join(registryDirPath, devfileDir.Name()))
+			continue
 		}
 
 		metaFilePath := filepath.Join(registryDirPath, devfileDir.Name(), meta)


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>

**Please specify the area for this PR**
Index generator

**What does does this PR do / why we need it**:
This PR makes index generator ignore non-directories in registry root directory so that avoiding failing to generate `index.json` when non-directory exists in registry root directory.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/187

**PR acceptance criteria**:

- [x] Test (WIP) 

- [x] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
1. Build the index-generator
2. `git clone https://github.com/odo-devfiles/registry`
3. `index-generator registry/devfiles index.json`