### PR TITLE
Add GitHub action to push metadata image

### DIFF
--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+name: Next Dockerimage
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout registry-support source code
+      uses: actions/checkout@v2
+    - name: Login to Quay
+      uses: docker/login-action@v1 
+      with:
+        registry: quay.io
+        username: ${{ secrets.QUAY_USERNAME }}
+        password: ${{ secrets.QUAY_PASSWORD }}
+    - name: Build the registry metadata image
+      run: cd oci-devfile-registry-metadata && ./build.sh
+    - name: Push the registry metadata image
+      run: cd oci-devfile-registry-metadata  && ./push.sh quay.io/devfile/metadata-server:next


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**What does does this PR do / why we need it**:
This PR adds a GitHub Workflow action to automatically push the metadata / bootstrap container image to `quay.io/devfile/metadata-server:next` on any commits to master.

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:
N/A