### PR TITLE
Add owners file for registry-support repo

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- elsony
+- geekarthur
+- johnmcollier
+
+reviewers:
+- elsony
+- geekarthur
+- johnmcollier


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**What does does this PR do / why we need it**:
Adds a top level OWNERS file for this repo, so that Prow can properly be used for PR reviews

**Which issue(s) this PR fixes**:

N/A
