### PR TITLE
Migrate registry build tools over from devfile/registry

### DIFF
--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -1,0 +1,12 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+FROM quay.io/devfile/devfile-index-base:next
+
+COPY index.json /index.json
+COPY stacks /stacks

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -1,0 +1,9 @@
+# Devfile Registry Build Tools
+
+This folder contains tools for building up a Devfile Registry Repository and packaging it and its generated index.json into a container image for deployment on an OCI Devfile Registry, hosted on Kubernetes. As we expand the functionality of the build tools and index generator, this will grow to include stack validation as well.
+
+## How to Run
+
+To build a devfile registry repository, run: `./build.sh <path-to-devfile-registry-folder>`.
+
+The build script will build the index generator, generate the index.json from the specified devfile registry, and build the stacks and index.json into a devfile index container image.

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -9,12 +9,12 @@
 
 #!/bin/sh
 
-buildToolsFolder="$(basename "$(dirname "$0")")"
+buildToolsFolder="$(dirname "$0")"
 generatorFolder=$buildToolsFolder/../index/generator
 
 display_usage() { 
   echo "A devfile registry repository folder must be passed in as an argument" 
-  echo "usage: ./build.sh <path-to-registry-repository-folder>" 
+  echo "usage: build.sh <path-to-registry-repository-folder>" 
 } 
 
 # Check if a registry repository folder was passed in, if not, exit
@@ -24,11 +24,12 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
+cd $generatorFolder
+
 # Build the index generator/validator
 echo "Building index-generator tool"
-cd $generatorFolder
 ./build.sh
-if [ ! $? -eq 0 ]; then
+if [ $? -ne 0 ]; then
   echo "Failed to build index-generator tool"
   exit 1
 fi
@@ -39,7 +40,7 @@ cd "$OLDPWD"
 # Run the index generator tool
 echo "Generate the devfile registry index"
 $generatorFolder/index-generator $registryFolder/stacks $registryFolder/index.json
-if [ ! $? -eq 0 ]; then
+if [ $? -ne 0 ]; then
   echo "Failed to build the devfile registry index"
   exit 1
 fi
@@ -48,7 +49,7 @@ echo -e "Successfully built the devfile registry index\n"
 # Build the Docker image containing the devfile stacks and index.json
 echo "Building the devfile registry index container"
 docker build -t devfile-index -f $buildToolsFolder/Dockerfile $registryFolder
-if [ ! $? -eq 0 ]; then
+if [ $? -ne 0 ]; then
   echo "Failed to build the devfile registry index container"
   exit 1
 fi

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#!/bin/sh
+
+buildToolsFolder="$(basename "$(dirname "$0")")"
+generatorFolder=$buildToolsFolder/../index/generator
+
+display_usage() { 
+  echo "A devfile registry repository folder must be passed in as an argument" 
+  echo "usage: ./build.sh <path-to-registry-repository-folder>" 
+} 
+
+# Check if a registry repository folder was passed in, if not, exit
+registryFolder=$1
+if [ $# -ne 1 ]; then
+  display_usage
+  exit 1
+fi
+
+# Build the index generator/validator
+echo "Building index-generator tool"
+cd $generatorFolder
+./build.sh
+if [ ! $? -eq 0 ]; then
+  echo "Failed to build index-generator tool"
+  exit 1
+fi
+echo -e "Successfully built the index-generator tool\n"
+
+cd "$OLDPWD"
+
+# Run the index generator tool
+echo "Generate the devfile registry index"
+$generatorFolder/index-generator $registryFolder/stacks $registryFolder/index.json
+if [ ! $? -eq 0 ]; then
+  echo "Failed to build the devfile registry index"
+  exit 1
+fi
+echo -e "Successfully built the devfile registry index\n"
+
+# Build the Docker image containing the devfile stacks and index.json
+echo "Building the devfile registry index container"
+docker build -t devfile-index -f $buildToolsFolder/Dockerfile $registryFolder
+if [ ! $? -eq 0 ]; then
+  echo "Failed to build the devfile registry index container"
+  exit 1
+fi
+
+echo "Successfully built the devfile registry index container"

--- a/build-tools/push.sh
+++ b/build-tools/push.sh
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2020 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+
+#!/bin/sh
+
+TAG=$1
+docker tag devfile-index $TAG
+docker push $TAG


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**Please specify the area for this PR**

**What does does this PR do / why we need it**:
Migrates the existing build scripts and Dockerfile from https://github.com/devfile/registry to this repository. No functional changes were made to the build tools, just a small change to allow the registry folder to be specified. Once this PR is merged, I'll remove the build tools from the registry repo.

The build tools are still relatively simplistic, but we can make further, centralized improvements to them in this repository now (under the `build-tools` folder), rather than on a per-registry basis.

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:
N/A

**How to test changes / Special notes to the reviewer**:
1. Git clone this repository and devfile/registry
2. cd to `build-tools` in this repository
3. run `./build.sh <path-to-cloned-devfile/registry>`

Build should succeed and produce a devfile index container image.