### PR TITLE
Add resources array to index schema

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -44,6 +44,16 @@ func GenerateIndexStruct(registryDirPath string) ([]schema.Schema, error) {
 		}
 		indexComponent.Links["self"] = fmt.Sprintf("%s/%s:%s", "devfile-catalog", indexComponent.Name, "latest")
 
+		// Get the files in the stack folder
+		stackFolder := filepath.Join(registryDirPath, devfileDir.Name())
+		stackFiles, err := ioutil.ReadDir(stackFolder)
+		for _, stackFile := range stackFiles {
+			// The registry build should have already packaged any folders and miscellaneous files into an archive.tar file
+			// But, add this check as a safeguard, as OCI doesn't support unarchived folders being pushed up.
+			if !stackFile.IsDir() {
+				indexComponent.Resources = append(indexComponent.Resources, stackFile.Name())
+			}
+		}
 		index = append(index, indexComponent)
 	}
 

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -59,5 +59,6 @@ type Schema struct {
 	ProjectType     string            `yaml:"projectType,omitempty" json:"projectType,omitempty"`
 	Language        string            `yaml:"language,omitempty" json:"language,omitempty"`
 	Links           map[string]string `yaml:"links,omitempty" json:"links,omitempty"`
+	Resources       []string          `yaml:"resources,omitempty" json:"resources,omitempty"`
 	StarterProjects []string          `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
 }


### PR DESCRIPTION
**What does does this PR do / why we need it**:
Adds the new resources sring array to the devfile registry index schema, as defined in the [devfile registry structure design doc](https://github.com/devfile/api/blob/master/docs/proposals/registry/registry-structure.md).

**Which issue(s) this PR fixes**:

github.com/devfile/api/issues/226

**PR acceptance criteria**:
N/A

**How to test changes / Special notes to the reviewer**:
The generated index.json should have a "resources" field in each entry.