### PR TITLE
Fix GitHub action that builds the images

### DIFF
--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -22,6 +22,7 @@ jobs:
     - name: Docker Build & Push
       uses: docker/build-push-action@v1.1.0
       with:
+        path: ./index/server
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
@@ -38,6 +39,7 @@ jobs:
     - name: Docker Build & Push
       uses: docker/build-push-action@v1.1.0
       with:
+        path: ./oci-registry
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**Please specify the area for this PR**

**What does does this PR do / why we need it**:

The GitHub actions that we switched to now require us to set `path` for the Docker build context for each image that we're building.