### PR TITLE
Support archive.tar on the registry build script

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -65,7 +65,6 @@ do
   tarFiles=$(find . \( -not -name 'devfile.yaml' \
     -a -not -name "meta.yaml" \
     -a -not -name "*.vsx" \
-    -a -not -name ".DS_Store" \
     -a -not -name "." \
     -a -not -name "logo.svg" \
     -a -not -name "logo.png" \) -maxdepth 1)

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -7,7 +7,10 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-#!/bin/sh
+#!/bin/bash
+
+# Enable extended globbing in the shell
+shopt -s extglob
 
 buildToolsFolder="$(dirname "$0")"
 generatorFolder=$buildToolsFolder/../index/generator
@@ -17,12 +20,20 @@ display_usage() {
   echo "usage: build.sh <path-to-registry-repository-folder>" 
 } 
 
+# cleanup_and_exit removes the temp folder we created and exits with the exit code passed into it
+clenaup_and_exit() {
+  rm -rf $registryFolder
+  exit $1
+}
 # Check if a registry repository folder was passed in, if not, exit
-registryFolder=$1
 if [ $# -ne 1 ]; then
   display_usage
   exit 1
 fi
+
+# Copy the registry repository over to a temp folder
+registryFolder=$(mktemp -d)
+cp -rf $1/. $registryFolder/
 
 cd $generatorFolder
 
@@ -31,7 +42,7 @@ echo "Building index-generator tool"
 ./build.sh
 if [ $? -ne 0 ]; then
   echo "Failed to build index-generator tool"
-  exit 1
+  clenaup_and_exit 1
 fi
 echo -e "Successfully built the index-generator tool\n"
 
@@ -42,16 +53,38 @@ echo "Generate the devfile registry index"
 $generatorFolder/index-generator $registryFolder/stacks $registryFolder/index.json
 if [ $? -ne 0 ]; then
   echo "Failed to build the devfile registry index"
-  exit 1
+  clenaup_and_exit 1
 fi
 echo -e "Successfully built the devfile registry index\n"
+
+# Generate the tar archive
+for stackDir in $registryFolder/stacks/*/
+do
+  cd $stackDir
+  # Find the files to add to the tar archive
+  tarFiles=$(find . \( -not -name 'devfile.yaml' \
+    -a -not -name "meta.yaml" \
+    -a -not -name "*.vsx" \
+    -a -not -name ".DS_Store" \
+    -a -not -name "." \
+    -a -not -name "logo.svg" \
+    -a -not -name "logo.png" \) -maxdepth 1)
+
+  # There are files that need to be pulled into a tar archive
+  if [[ ! -z $tarFiles ]]; then
+    tar -cvf archive.tar $tarFiles
+    rm -rf $tarFiles
+  fi
+  cd "$OLDPWD"
+done
 
 # Build the Docker image containing the devfile stacks and index.json
 echo "Building the devfile registry index container"
 docker build -t devfile-index -f $buildToolsFolder/Dockerfile $registryFolder
 if [ $? -ne 0 ]; then
   echo "Failed to build the devfile registry index container"
-  exit 1
+  clenaup_and_exit 1
 fi
 
 echo "Successfully built the devfile registry index container"
+clenaup_and_exit


### PR DESCRIPTION
**What does does this PR do / why we need it**:
This PR fixes the registry build tools so that the archive.tar file is properly created when a devfile registry repository is built.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/315

**PR acceptance criteria**:
N/A

**How to test changes / Special notes to the reviewer**:
1. Checkout my changes and git clone github.com/devfile/registry
2. cd to `build-tools/`
3. Run `build.sh <path-to-registry-repository-on-disk>`. A docker container image should successfully be built
4. Run `docker run -P -dt devfile-index:latest`
5. Run `docker ps` and get the id of the container. Run `docker exec <container-id> ls /stacks/nodejs`. The output should contain `archive.tar`