### PR TITLE
Fix registry build

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -62,7 +62,7 @@ do
 
   # There are files that need to be pulled into a tar archive
   if [[ ! -z $tarFiles ]]; then
-    tar -cvf archive.tar $tarFiles
+    tar -czvf archive.tar $tarFiles
     rm -rf $tarFiles
   fi
   cd "$OLDPWD"


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfwan@redhat.com>

**What does does this PR do / why we need it**:
This PR lets `tar` uses compression option when creating the `archive.tar` file to make the `archive.tar` compatible with registry library and save more disk.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/224

**PR acceptance criteria**:

- [x] Test (WIP) 

- [x] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
1. Install registry operator then deploy registry
2. Run registry CLI `registry pull nodejs -a` to pull down the whole stack to verify `archive.tar` file can be extracted