### PR TITLE
(Hosted Registry) Add configuration for number of registry replicas and remove routes

### DIFF
--- a/deploy/hosted-registry/devfile-registry.yaml
+++ b/deploy/hosted-registry/devfile-registry.yaml
@@ -19,7 +19,7 @@ objects:
       app: devfile-registry
     name: devfile-registry
   spec:
-    replicas: 1
+    replicas: ${{REPLICAS}}
     selector:
       matchLabels:
         app: devfile-registry
@@ -217,3 +217,7 @@ parameters:
   value: Always
   displayName: Devfile registry image pull policy
   description: Always pull by default. Can be IfNotPresent
+- name: REPLICAS
+  value: 1
+  displayName: Devfile registry replicas
+  description: The number of replicas for the hosted devfile registry service

--- a/deploy/hosted-registry/devfile-registry.yaml
+++ b/deploy/hosted-registry/devfile-registry.yaml
@@ -120,41 +120,6 @@ objects:
     selector:
       app: devfile-registry
 - apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      app: devfile-registry
-    name: devfile-registry
-  spec:
-    host: ${DEVFILE_REGISTRY_HOST}
-    to:
-      kind: Service
-      name: devfile-registry
-      weight: 100
-    port:
-      targetPort: 8080
-    tls:
-      termination: edge
-      insecureEdgeTerminationPolicy: Redirect
-- apiVersion: v1
-  kind: Route
-  metadata:
-    labels:
-      app: devfile-registry
-    name: oci-registry
-  spec:
-    host: ${DEVFILE_REGISTRY_HOST}
-    path: /v2
-    to:
-      kind: Service
-      name: devfile-registry
-      weight: 100
-    port:
-      targetPort: 8080
-    tls:
-      termination: edge
-      insecureEdgeTerminationPolicy: Redirect
-- apiVersion: v1
   kind: ConfigMap
   metadata:
     name: devfile-registry
@@ -180,11 +145,6 @@ objects:
             path: /metrics
 
 parameters:
-- name: DEVFILE_REGISTRY_HOST
-  value: ""
-  displayName: Devfile registry hostname
-  description: Hostname for the devfile registry service. Defaults to cluster's router.
-  required: false
 - name: DEVFILE_INDEX_IMAGE
   value: quay.io/devfile/devfile-index
   displayName: Devfile registry index image

--- a/deploy/hosted-registry/devfile-registry.yaml
+++ b/deploy/hosted-registry/devfile-registry.yaml
@@ -19,7 +19,7 @@ objects:
       app: devfile-registry
     name: devfile-registry
   spec:
-    replicas: ${{REPLICAS}}
+    replicas: ${REPLICAS}
     selector:
       matchLabels:
         app: devfile-registry

--- a/deploy/hosted-registry/route.yaml
+++ b/deploy/hosted-registry/route.yaml
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: devfile-registry
+objects:
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: devfile-registry
+    name: devfile-registry
+  spec:
+    host: ${DEVFILE_REGISTRY_HOST}
+    to:
+      kind: Service
+      name: devfile-registry
+      weight: 100
+    port:
+      targetPort: 8080
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+- apiVersion: v1
+  kind: Route
+  metadata:
+    labels:
+      app: devfile-registry
+    name: oci-registry
+  spec:
+    host: ${DEVFILE_REGISTRY_HOST}
+    path: /v2
+    to:
+      kind: Service
+      name: devfile-registry
+      weight: 100
+    port:
+      targetPort: 8080
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Redirect
+
+parameters:
+- name: DEVFILE_REGISTRY_HOST
+  value: ""
+  displayName: Devfile registry hostname
+  description: Hostname for the devfile registry service. Defaults to cluster's router.
+  required: false


### PR DESCRIPTION
**What does does this PR do / why we need it**:
This PR adds a couple required changes to deploy the hosted registry on the managed OpenShift Dedicated environment:
- Adds a configuration in the OpenShift template to allow the number of devfile registry replicas to be configured. 
- Removes routes from the main `devfile-registry.yaml` OpenShift template. 
    - This is because OpenShift routes will be configured and managed through a separate process.
    - I've included a `route.yaml` with the routes for debugging purposes.

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [ ] Test (WIP) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
1. Log in to an OpenShift cluster
2. Run `REPLICAS=3 oc new-app -f deploy/hosted-registry/
3. The devfile registry should get deployed and there should be 3 pods deployed.