### PR TITLE
Fix replicas parameter in OpenShift template

### DIFF
--- a/deploy/hosted-registry/devfile-registry.yaml
+++ b/deploy/hosted-registry/devfile-registry.yaml
@@ -19,7 +19,7 @@ objects:
       app: devfile-registry
     name: devfile-registry
   spec:
-    replicas: ${REPLICAS}
+    replicas: ${{REPLICAS}}
     selector:
       matchLabels:
         app: devfile-registry
@@ -178,6 +178,6 @@ parameters:
   displayName: Devfile registry image pull policy
   description: Always pull by default. Can be IfNotPresent
 - name: REPLICAS
-  value: 1
+  value: "1"
   displayName: Devfile registry replicas
   description: The number of replicas for the hosted devfile registry service


### PR DESCRIPTION
**What does does this PR do / why we need it**:
This PR fixes the `REPLICAS` parameter when deploying the hosted devfile registry through the app-sre CICD pipelines. The issue was that the `values` field for OpenShift parameters expects a string and not an integer, so quotes around the default value for `REPLICAS` was needed, as well as double curly brackets around the parameter when referencing it.

**Which issue(s) this PR fixes**:

N/A