### PR TITLE
Add label for registry service

### DIFF
--- a/deploy/hosted-registry/devfile-registry.yaml
+++ b/deploy/hosted-registry/devfile-registry.yaml
@@ -103,6 +103,8 @@ objects:
   kind: Service
   metadata:
     name: devfile-registry
+    labels:
+      app: devfile-registry
   spec:
     ports:
       - name: http


### PR DESCRIPTION
Adds a `app: devfile-registry` label to the hosted registry service, so that Prometheus can find and scrape its metrics endpoints