### PR TITLE
Add starter projects field to index

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -42,16 +42,20 @@ func GenerateIndexStruct(registryDirPath string, force bool) ([]schema.Schema, e
 		if err != nil {
 			return nil, fmt.Errorf("failed to read %s: %v", devfilePath, err)
 		}
-		var meta schema.Meta
-		err = yaml.Unmarshal(bytes, &meta)
+		var devfile schema.Devfile
+		err = yaml.Unmarshal(bytes, &devfile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to unmarshal %s data: %v", devfilePath, err)
 		}
-		indexComponent := meta.Schema
+		indexComponent := devfile.Meta
 		if indexComponent.Links == nil {
 			indexComponent.Links = make(map[string]string)
 		}
 		indexComponent.Links["self"] = fmt.Sprintf("%s/%s:%s", "devfile-catalog", indexComponent.Name, "latest")
+
+		for _, starterProject := range devfile.StarterProjects {
+			indexComponent.StarterProjects = append(indexComponent.StarterProjects, starterProject.Name)
+		}
 
 		// Get the files in the stack folder
 		stackFolder := filepath.Join(registryDirPath, devfileDir.Name())

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -71,7 +71,13 @@ type Schema struct {
 	StarterProjects []string          `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
 }
 
-// Meta is the devfile metadata
-type Meta struct {
-	Schema Schema `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+// StarterProject is the devfile starter project
+type StarterProject struct {
+	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+// Devfile is the devfile structure that is used by index component
+type Devfile struct {
+	Meta            Schema           `yaml:"metadata,omitempty" json:"metadata,omitempty"`
+	StarterProjects []StarterProject `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
 }


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfwan@redhat.com>

**What does does this PR do / why we need it**:
This PR implements/updates `starterProjects` field for each devfile in the index, so that consumers can get starter projects for each devfile directly from index.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/115

**PR acceptance criteria**:

- [x] Test (WIP) 

- [x] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
1. Build the index generator
2. Run `index-generator  <registry directory path> index.json`
3. Verify the `index.json` contains `starterProjects` field for each devfile
