### PR TITLE
Allow hosted registry pods to get refreshed on updates

### DIFF
--- a/deploy/hosted-registry/devfile-registry.yaml
+++ b/deploy/hosted-registry/devfile-registry.yaml
@@ -125,6 +125,8 @@ objects:
   kind: ConfigMap
   metadata:
     name: devfile-registry
+    annotations:
+      qontract.recycle: "true"
   data:
     registry-config.yml: |
       version: 0.1


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**Please specify the area for this PR**
This PR updates the OpenShift template for the hosted devfile registry to add the `qontract.recycle: "true"` annotation to the oci registry configmap. This is so that any updates to the configmap will cause existing, deployed pods to be automatically redeployed when refreshing the devfile registry.