### PR TITLE
Add OpenShift template for devfile.io redirector

### DIFF
--- a/deploy/hosted-registry/redirector/redirector.yaml
+++ b/deploy/hosted-registry/redirector/redirector.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: Template
+metadata:
+  creationTimestamp: null
+  name: redirector
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    creationTimestamp: null
+    generation: 1
+    labels:
+      run: redirector
+    name: redirector
+  spec:
+    replicas: 1
+    selector:
+      run: redirector
+    strategy:
+      rollingParams:
+        intervalSeconds: 1
+        maxSurge: 25%
+        maxUnavailable: 25%
+        timeoutSeconds: 600
+        updatePeriodSeconds: 1
+      type: Rolling
+    template:
+      metadata:
+        creationTimestamp: null
+        labels:
+          run: redirector
+      spec:
+        containers:
+        - env:
+          - name: REDIRECTOR_DESTINATION
+            valueFrom:
+                configMapKeyRef:
+                  name: redirector
+                  key: redirector.destination
+          - name: REDIRECTOR_TYPE
+            valueFrom:
+                configMapKeyRef:
+                  name: redirector
+                  key: redirector.type
+          image: ${IMAGE}:${IMAGE_TAG}
+          imagePullPolicy: Always
+          name: redirector
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          terminationMessagePath: /dev/termination-log
+          resources:
+            requests:
+              cpu: 20m
+              memory: 10Mi
+            limits:
+              cpu: 40m
+              memory: 40Mi
+        dnsPolicy: ClusterFirst
+        restartPolicy: Always
+        securityContext: {}
+        terminationGracePeriodSeconds: 30
+    test: false
+    triggers:
+    - type: ConfigChange
+  status: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    creationTimestamp: null
+    name: redirector
+  spec:
+    ports:
+    - name: "8080"
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      run: redirector
+    sessionAffinity: None
+    type: ClusterIP
+  status:
+    loadBalancer: {}
+parameters:
+- name: IMAGE
+  value: "quay.io/app-sre/nginx-redirector"
+- name: IMAGE_TAG
+  value: "latest"

--- a/deploy/hosted-registry/redirector/redirector.yaml
+++ b/deploy/hosted-registry/redirector/redirector.yaml
@@ -4,8 +4,8 @@ metadata:
   creationTimestamp: null
   name: redirector
 objects:
-- apiVersion: v1
-  kind: DeploymentConfig
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     creationTimestamp: null
     generation: 1
@@ -15,7 +15,8 @@ objects:
   spec:
     replicas: 1
     selector:
-      run: redirector
+      matchLabels:
+        run: redirector
     strategy:
       rollingParams:
         intervalSeconds: 1
@@ -23,7 +24,7 @@ objects:
         maxUnavailable: 25%
         timeoutSeconds: 600
         updatePeriodSeconds: 1
-      type: Rolling
+      type: RollingUpdate
     template:
       metadata:
         creationTimestamp: null


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**What does does this PR do / why we need it**:
Adds an OpenShift template for properly redirecting devfile.io to docs.devfile.io. Required to fix redirect that was broken when we moved to the AppSRE AWS nameservers.