### PR TITLE
Add context support for registry library

### DIFF
--- a/registry-library/cmd/root.go
+++ b/registry-library/cmd/root.go
@@ -33,6 +33,7 @@ var (
 	registry     = os.Getenv("REGISTRY")
 	cfgFile      string
 	allResources bool
+	destDir      string
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -77,9 +78,9 @@ func init() {
 			var err error
 
 			if allResources {
-				err = library.PullStackFromRegistry(registry, stack)
+				err = library.PullStackFromRegistry(registry, stack, destDir)
 			} else {
-				err = library.PullStackByMediaTypesFromRegistry(registry, stack, library.DevfileMediaTypeList)
+				err = library.PullStackByMediaTypesFromRegistry(registry, stack, library.DevfileMediaTypeList, destDir)
 			}
 			if err != nil {
 				fmt.Printf("Failed to pull %s from registry %s: %v\n", stack, registry, err)
@@ -87,6 +88,7 @@ func init() {
 		},
 	}
 	pullCmd.Flags().BoolVarP(&allResources, "all", "a", false, "pull all resources of the given stack")
+	pullCmd.Flags().StringVar(&destDir, "context", ".", "destination directory that stores stack resources")
 
 	var listCmd = &cobra.Command{
 		Use:   "list",


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfwan@redhat.com>

**Please specify the area for this PR**
Registry library

**What does does this PR do / why we need it**:
This PR adds the context support for registry library.

**Which issue(s) this PR fixes**:

Related issue: https://github.com/devfile/api/issues/367

**PR acceptance criteria**:

- [x] Test (WIP) 

- [x] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
1. Run `./build.sh` to build the registry binary
2. Run `./registry pull nodejs --context <destination directory path> --all`, verify the nodejs stack resources are downloaded to the destination directory path.
