### PR TITLE
Revert to sha-cd27952 for registry dockerfile

### DIFF
--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -26,7 +26,7 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
-        repository: jcollier/devfile-index-base
+        repository: devfile/devfile-index-base
         dockerfile: ./index/server/Dockerfile
         tags: next
         tag_with_sha: true
@@ -57,7 +57,7 @@ jobs:
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
         registry: quay.io
-        repository: jcollier/oci-registry
+        repository: devfile/oci-registry
         dockerfile: ./oci-registry/Dockerfile
         tags: next
         tag_with_sha: true

--- a/build-tools/Dockerfile
+++ b/build-tools/Dockerfile
@@ -6,7 +6,7 @@
 #
 # SPDX-License-Identifier: EPL-2.0
 #
-FROM quay.io/devfile/devfile-index-base:next
+FROM quay.io/devfile/devfile-index-base:sha-cd27952 
 
 COPY index.json /index.json
 COPY stacks /stacks


### PR DESCRIPTION
Couple small changes

- Reverts the build-tools dockerfile to `sha-cd27952` for the base image due to https://github.com/devfile/api/issues/444
- Fixes some typos I made in the github action to push images to quay.io. They should **not** be pointing to my personal repo 🤦 