### PR TITLE
Exit with proper code for build script

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -22,7 +22,7 @@ display_usage() {
 # cleanup_and_exit removes the build folder and exits with the exit code passed into it
 cleanup_and_exit() {
   rm -rf $outputFolder
-  exit 1
+  exit $1
 }
 
 # build_registry <registry-folder> <output>

--- a/build-tools/build_image.sh
+++ b/build-tools/build_image.sh
@@ -20,7 +20,7 @@ display_usage() {
 # cleanup_and_exit removes the temp folder we created and exits with the exit code passed into it
 cleanup_and_exit() {
   rm -rf $registryFolder
-  exit 1
+  exit $1
 }
 
 # Check if a registry repository folder was passed in, if not, exit


### PR DESCRIPTION
Typo in the cleanup_exit_function in the registry build scripts. Should be `exit $1` instead of `exit 1`