### PR TITLE
Fix no extra devfile entries case

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -22,18 +22,21 @@ const (
 // GenerateIndexStruct parses registry then generates index struct according to the schema
 func GenerateIndexStruct(registryDirPath string, force bool) ([]schema.Schema, error) {
 	// Parse devfile registry then populate index struct
-	indexFromDevfileRegistry, err := parseDevfileRegistry(registryDirPath, force)
+	index, err := parseDevfileRegistry(registryDirPath, force)
 	if err != nil {
-		return indexFromDevfileRegistry, err
+		return index, err
 	}
 
-	// Parse extraDevfileEntries.yaml then populate the index struct
-	indexFromExtraDevfileEntries, err := parseExtraDevfileEntries(registryDirPath, force)
-	if err != nil {
-		return indexFromExtraDevfileEntries, err
+	// Parse extraDevfileEntries.yaml then populate the index struct (optional)
+	extraDevfileEntriesPath := path.Join(registryDirPath, extraDevfileEntries)
+	if fileExists(extraDevfileEntriesPath) {
+		indexFromExtraDevfileEntries, err := parseExtraDevfileEntries(registryDirPath, force)
+		if err != nil {
+			return index, err
+		}
+		index = append(index, indexFromExtraDevfileEntries...)
 	}
 
-	index := append(indexFromDevfileRegistry, indexFromExtraDevfileEntries...)
 	return index, nil
 }
 


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfwan@redhat.com>

**Please specify the area for this PR**
index generator

**What does does this PR do / why we need it**:
This PR fixes the case where `extraDevfileEntries.yaml` doesn't exist, we need to skip it  as `extraDevfileEntries` is optional to the registry.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/443

**PR acceptance criteria**:

- [x] Test (WIP) 

- [x] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
Try index generator without `extraDevfileEntries.yaml` in the registry.
