### PR TITLE
Fix index server extra samples/stacks push issue

### DIFF
--- a/index/server/main.go
+++ b/index/server/main.go
@@ -112,9 +112,11 @@ func main() {
 
 	// Before starting the server, push the devfile artifacts to the registry
 	for _, devfileIndex := range index {
-		err := pushStackToRegistry(devfileIndex)
-		if err != nil {
-			log.Fatal(err.Error())
+		if len(devfileIndex.Resources) != 0 {
+			err := pushStackToRegistry(devfileIndex)
+			if err != nil {
+				log.Fatal(err.Error())
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: jingfu wang <jingfwan@redhat.com>

**Please specify the area for this PR**

**What does does this PR do / why we need it**:
This PR fixes the resource pushing issue happens on extra samples/stacks from `extraDevfilesEntry.yaml` as those extra samples/stacks don't contain any resource.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/444

**PR acceptance criteria**:

- [x] Test (WIP) 

- [x] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
Bootstrap the index server and there is no issue.