### PR TITLE
Disable TLS on the dev/test devfile registry routes

### DIFF
--- a/deploy/hosted-registry/route.yaml
+++ b/deploy/hosted-registry/route.yaml
@@ -26,9 +26,6 @@ objects:
       weight: 100
     port:
       targetPort: 8080
-    tls:
-      termination: edge
-      insecureEdgeTerminationPolicy: Redirect
 - apiVersion: v1
   kind: Route
   metadata:
@@ -44,9 +41,6 @@ objects:
       weight: 100
     port:
       targetPort: 8080
-    tls:
-      termination: edge
-      insecureEdgeTerminationPolicy: Redirect
 
 parameters:
 - name: DEVFILE_REGISTRY_HOST


### PR DESCRIPTION
The devfile registry route used for testing the registry on the OpenShift CI needs to be HTTP for the time being due to https://github.com/devfile/api/issues/388. Since the route template in this repo is **not** used for the production registry (the routes for prod/staging are stored in app-interface), and only used for testing/dev, we can safely disable TLS for the time being.