### PR TITLE
Update index type from string to enum

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -55,8 +55,8 @@ func CreateIndexFile(index []schema.Schema, indexFilePath string) error {
 	return nil
 }
 
-func validateIndexComponent(indexComponent schema.Schema, componentType schema.IndexType) error {
-	if componentType == schema.StackIndexType {
+func validateIndexComponent(indexComponent schema.Schema, componentType schema.DevfileType) error {
+	if componentType == schema.StackDevfileType {
 		if indexComponent.Name == "" {
 			return fmt.Errorf("index component name is not initialized")
 		}
@@ -66,7 +66,7 @@ func validateIndexComponent(indexComponent schema.Schema, componentType schema.I
 		if indexComponent.Resources == nil {
 			return fmt.Errorf("index component resources are empty")
 		}
-	} else if componentType == schema.SampleIndexType {
+	} else if componentType == schema.SampleDevfileType {
 		if indexComponent.Git == nil {
 			return fmt.Errorf("index component git is empty")
 		}
@@ -127,7 +127,7 @@ func parseDevfileRegistry(registryDirPath string, force bool) ([]schema.Schema, 
 			indexComponent.Links = make(map[string]string)
 		}
 		indexComponent.Links["self"] = fmt.Sprintf("%s/%s:%s", "devfile-catalog", indexComponent.Name, "latest")
-		indexComponent.Type = schema.StackIndexType
+		indexComponent.Type = schema.StackDevfileType
 
 		for _, starterProject := range devfile.StarterProjects {
 			indexComponent.StarterProjects = append(indexComponent.StarterProjects, starterProject.Name)
@@ -146,7 +146,7 @@ func parseDevfileRegistry(registryDirPath string, force bool) ([]schema.Schema, 
 
 		if !force {
 			// Index component validation
-			err := validateIndexComponent(indexComponent, schema.StackIndexType)
+			err := validateIndexComponent(indexComponent, schema.StackDevfileType)
 			if err != nil {
 				return nil, fmt.Errorf("%s index component is not valid: %v", devfileDir.Name(), err)
 			}
@@ -170,12 +170,12 @@ func parseExtraDevfileEntries(registryDirPath string, force bool) ([]schema.Sche
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal %s data: %v", extraDevfileEntriesPath, err)
 	}
-	devfileTypes := []schema.IndexType{schema.SampleIndexType, schema.StackIndexType}
+	devfileTypes := []schema.DevfileType{schema.SampleDevfileType, schema.StackDevfileType}
 	for _, devfileType := range devfileTypes {
 		var devfileEntriesWithType []schema.Schema
-		if devfileType == schema.SampleIndexType {
+		if devfileType == schema.SampleDevfileType {
 			devfileEntriesWithType = devfileEntries.Samples
-		} else if devfileType == schema.StackIndexType {
+		} else if devfileType == schema.StackDevfileType {
 			devfileEntriesWithType = devfileEntries.Stacks
 		}
 		for _, devfileEntry := range devfileEntriesWithType {

--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -55,8 +55,8 @@ func CreateIndexFile(index []schema.Schema, indexFilePath string) error {
 	return nil
 }
 
-func validateIndexComponent(indexComponent schema.Schema, componentType string) error {
-	if componentType == "stack" {
+func validateIndexComponent(indexComponent schema.Schema, componentType schema.IndexType) error {
+	if componentType == schema.StackIndexType {
 		if indexComponent.Name == "" {
 			return fmt.Errorf("index component name is not initialized")
 		}
@@ -66,7 +66,7 @@ func validateIndexComponent(indexComponent schema.Schema, componentType string) 
 		if indexComponent.Resources == nil {
 			return fmt.Errorf("index component resources are empty")
 		}
-	} else if componentType == "sample" {
+	} else if componentType == schema.SampleIndexType {
 		if indexComponent.Git == nil {
 			return fmt.Errorf("index component git is empty")
 		}
@@ -127,7 +127,7 @@ func parseDevfileRegistry(registryDirPath string, force bool) ([]schema.Schema, 
 			indexComponent.Links = make(map[string]string)
 		}
 		indexComponent.Links["self"] = fmt.Sprintf("%s/%s:%s", "devfile-catalog", indexComponent.Name, "latest")
-		indexComponent.Type = "stack"
+		indexComponent.Type = schema.StackIndexType
 
 		for _, starterProject := range devfile.StarterProjects {
 			indexComponent.StarterProjects = append(indexComponent.StarterProjects, starterProject.Name)
@@ -146,7 +146,7 @@ func parseDevfileRegistry(registryDirPath string, force bool) ([]schema.Schema, 
 
 		if !force {
 			// Index component validation
-			err := validateIndexComponent(indexComponent, "stack")
+			err := validateIndexComponent(indexComponent, schema.StackIndexType)
 			if err != nil {
 				return nil, fmt.Errorf("%s index component is not valid: %v", devfileDir.Name(), err)
 			}
@@ -170,12 +170,12 @@ func parseExtraDevfileEntries(registryDirPath string, force bool) ([]schema.Sche
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal %s data: %v", extraDevfileEntriesPath, err)
 	}
-	devfileTypes := []string{"sample", "stack"}
+	devfileTypes := []schema.IndexType{schema.SampleIndexType, schema.StackIndexType}
 	for _, devfileType := range devfileTypes {
 		var devfileEntriesWithType []schema.Schema
-		if devfileType == "sample" {
+		if devfileType == schema.SampleIndexType {
 			devfileEntriesWithType = devfileEntries.Samples
-		} else if devfileType == "stack" {
+		} else if devfileType == schema.StackIndexType {
 			devfileEntriesWithType = devfileEntries.Stacks
 		}
 		for _, devfileEntry := range devfileEntriesWithType {

--- a/index/generator/library/library_test.go
+++ b/index/generator/library/library_test.go
@@ -13,7 +13,7 @@ func TestValidateIndexComponent(t *testing.T) {
 	tests := []struct {
 		name           string
 		indexComponent schema.Schema
-		componentType  schema.IndexType
+		componentType  schema.DevfileType
 		wantErr        bool
 	}{
 		{
@@ -26,7 +26,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					"devfile.yaml",
 				},
 			},
-			schema.StackIndexType,
+			schema.StackDevfileType,
 			true,
 		},
 		{
@@ -37,7 +37,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					"devfile.yaml",
 				},
 			},
-			schema.StackIndexType,
+			schema.StackDevfileType,
 			true,
 		},
 		{
@@ -48,7 +48,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					"self": "devfile-catalog/java-maven:latest",
 				},
 			},
-			schema.StackIndexType,
+			schema.StackDevfileType,
 			true,
 		},
 		{
@@ -56,7 +56,7 @@ func TestValidateIndexComponent(t *testing.T) {
 			schema.Schema{
 				Name: "nodejs",
 			},
-			schema.SampleIndexType,
+			schema.SampleDevfileType,
 			true,
 		},
 		{
@@ -70,7 +70,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					"devfile.yaml",
 				},
 			},
-			schema.StackIndexType,
+			schema.StackDevfileType,
 			false,
 		},
 		{
@@ -83,7 +83,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					},
 				},
 			},
-			schema.SampleIndexType,
+			schema.SampleDevfileType,
 			false,
 		},
 	}

--- a/index/generator/library/library_test.go
+++ b/index/generator/library/library_test.go
@@ -13,7 +13,7 @@ func TestValidateIndexComponent(t *testing.T) {
 	tests := []struct {
 		name           string
 		indexComponent schema.Schema
-		componentType  string
+		componentType  schema.IndexType
 		wantErr        bool
 	}{
 		{
@@ -26,7 +26,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					"devfile.yaml",
 				},
 			},
-			"stack",
+			schema.StackIndexType,
 			true,
 		},
 		{
@@ -37,7 +37,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					"devfile.yaml",
 				},
 			},
-			"stack",
+			schema.StackIndexType,
 			true,
 		},
 		{
@@ -48,7 +48,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					"self": "devfile-catalog/java-maven:latest",
 				},
 			},
-			"stack",
+			schema.StackIndexType,
 			true,
 		},
 		{
@@ -56,7 +56,7 @@ func TestValidateIndexComponent(t *testing.T) {
 			schema.Schema{
 				Name: "nodejs",
 			},
-			"sample",
+			schema.SampleIndexType,
 			true,
 		},
 		{
@@ -70,7 +70,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					"devfile.yaml",
 				},
 			},
-			"stack",
+			schema.StackIndexType,
 			false,
 		},
 		{
@@ -83,7 +83,7 @@ func TestValidateIndexComponent(t *testing.T) {
 					},
 				},
 			},
-			"sample",
+			schema.SampleIndexType,
 			false,
 		},
 	}

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -57,7 +57,7 @@ version: string - The stack version
 attributes: map[string]apiext.JSON - Map of implementation-dependant free-form YAML attributes
 displayName: string - The display name of devfile
 description: string - The description of devfile
-type: string - The type of the devfile, currently support stack and sample
+type: DevfileType - The type of the devfile, currently supports stack and sample
 tags: string[] - The tags associated to devfile
 icon: string - The devfile icon
 globalMemoryLimit: string - The devfile global memory limit
@@ -76,7 +76,7 @@ type Schema struct {
 	Attributes        map[string]apiext.JSON `yaml:"attributes,omitempty" json:"attributes,omitempty"`
 	DisplayName       string                 `yaml:"displayName,omitempty" json:"displayName,omitempty"`
 	Description       string                 `yaml:"description,omitempty" json:"description,omitempty"`
-	Type              IndexType              `yaml:"type,omitempty" json:"type,omitempty"`
+	Type              DevfileType            `yaml:"type,omitempty" json:"type,omitempty"`
 	Tags              []string               `yaml:"tags,omitempty" json:"tags,omitempty"`
 	Icon              string                 `yaml:"icon,omitempty" json:"icon,omitempty"`
 	GlobalMemoryLimit string                 `yaml:"globalMemoryLimit,omitempty" json:"globalMemoryLimit,omitempty"`
@@ -88,15 +88,15 @@ type Schema struct {
 	Git               *Git                   `yaml:"git,omitempty" json:"git,omitempty"`
 }
 
-// IndexType describes the type of index entry
-type IndexType string
+// DevfileType describes the type of devfile
+type DevfileType string
 
 const (
-	// SampleIndexType represents a sample index
-	SampleIndexType IndexType = "sample"
+	// SampleDevfileType represents a sample devfile
+	SampleDevfileType DevfileType = "sample"
 
-	// StackIndexType represents a stack index
-	StackIndexType IndexType = "stack"
+	// StackDevfileType represents a stack devfile
+	StackDevfileType DevfileType = "stack"
 )
 
 // StarterProject is the devfile starter project

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -57,7 +57,7 @@ version: string - The stack version
 attributes: map[string]apiext.JSON - Map of implementation-dependant free-form YAML attributes
 displayName: string - The display name of devfile
 description: string - The description of devfile
-Type: string - The type of the devfile, currently support stack and sample
+type: string - The type of the devfile, currently support stack and sample
 tags: string[] - The tags associated to devfile
 icon: string - The devfile icon
 globalMemoryLimit: string - The devfile global memory limit
@@ -76,7 +76,7 @@ type Schema struct {
 	Attributes        map[string]apiext.JSON `yaml:"attributes,omitempty" json:"attributes,omitempty"`
 	DisplayName       string                 `yaml:"displayName,omitempty" json:"displayName,omitempty"`
 	Description       string                 `yaml:"description,omitempty" json:"description,omitempty"`
-	Type              string                 `yaml:"type,omitempty" json:"type,omitempty"`
+	Type              IndexType              `yaml:"type,omitempty" json:"type,omitempty"`
 	Tags              []string               `yaml:"tags,omitempty" json:"tags,omitempty"`
 	Icon              string                 `yaml:"icon,omitempty" json:"icon,omitempty"`
 	GlobalMemoryLimit string                 `yaml:"globalMemoryLimit,omitempty" json:"globalMemoryLimit,omitempty"`
@@ -87,6 +87,17 @@ type Schema struct {
 	StarterProjects   []string               `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
 	Git               *Git                   `yaml:"git,omitempty" json:"git,omitempty"`
 }
+
+// IndexType describes the type of index entry
+type IndexType string
+
+const (
+	// SampleIndexType represents a sample index
+	SampleIndexType IndexType = "sample"
+
+	// StackIndexType represents a stack index
+	StackIndexType IndexType = "stack"
+)
 
 // StarterProject is the devfile starter project
 type StarterProject struct {


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

**Please specify the area for this PR**
Index Schema

**What does does this PR do / why we need it**:
Updating the index schema type from string to enum, brought up here in this PR https://github.com/openshift/console/pull/8687#discussion_r623406909 and thought this was a good small change to make

I've also searched for `"sample"`  and `"stack"` strings and replaced them

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [x] Test (Updated) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
updated the tests, so pls run the go tests
