### PR TITLE
Update Helm chart defaults

### DIFF
--- a/deploy/chart/devfile-registry/README.md
+++ b/deploy/chart/devfile-registry/README.md
@@ -8,9 +8,9 @@ Installing this chart will deploy an OCI-based devfile registry on to your Kuber
 - Helm CLI, version 3 or higher
 - Knowledge of your cluster's ingress domain
 
-## Installing the Devfile Registry
+## Installing the Devfile Registry on Kubernetes
 
-Run the following command to install the devfile registry on to your cluster:
+Run the following command to install the devfile registry on to your Kubernetes Cluster:
 
 ```
 helm install <release-name> <path-to-chart> --set global.ingress.domain=<ingress-domain>
@@ -21,9 +21,16 @@ E.g. if your cluster's ingress domain is 192.168.1.0.nip.io, you would run:
 helm install devfile-registry deploy/chart/devfile-registry --set global.ingress.domain=192.168.1.0.nip.io
 ```
 
+## Installing the Devfile Registry on OpenShift
+
 If you're installing on OpenShift, you need to set `global.isOpenShift` to true, for example:
 ```
 helm install devfile-registry deploy/chart/devfile-registry --set global.isOpenShift=true
+```
+
+or, if you want to install a specific devfile index image, you can run:
+```
+helm install devfile-registry deploy/chart/devfile-registry --set global.isOpenShift=true --set devfileIndex.image=quay.io/myuser/devfile-index --set defileIndex.tag=latest
 ```
 
 ## Updating the Devfile Registry

--- a/deploy/chart/devfile-registry/README.md
+++ b/deploy/chart/devfile-registry/README.md
@@ -21,6 +21,11 @@ E.g. if your cluster's ingress domain is 192.168.1.0.nip.io, you would run:
 helm install devfile-registry deploy/chart/devfile-registry --set global.ingress.domain=192.168.1.0.nip.io
 ```
 
+If you're installing on OpenShift, you need to set `global.isOpenShift` to true, for example:
+```
+helm install devfile-registry deploy/chart/devfile-registry --set global.isOpenShift=true
+```
+
 ## Updating the Devfile Registry
 
 If you wish to update the devfile registry (such as to add change the devfile index image or change some configurations), you can run the following command:
@@ -54,6 +59,7 @@ The following fields can be configured in the Helm chart, either via the `values
 | `global.ingress.class`                 | Ingress class for the devfile registry          | `nginx` |
 | `global.ingress.secretName`            | Name of an existing tls secret if using TLS     | ` '' ` |
 | `global.isOpenShift  `                 | Set to true to use OpenShift routes instead of ingress   | `false` |
+| `global.tlsEnabled`                    | Set to true to use the devfile registry with TLS | `false` |
 | `devfileIndex.image`                   | Image used for the devfile index image          | `quay.io/devfile/devfile-index` |
 | `devfileIndex.tag`                     | Tag for devfile index image                     | `next` |
 | `devfileIndex.imagePullpolicy`         | Image pull policy for devfile index image       | `Always` |

--- a/deploy/chart/devfile-registry/templates/ingress.yaml
+++ b/deploy/chart/devfile-registry/templates/ingress.yaml
@@ -27,7 +27,7 @@ spec:
         backend:
           serviceName: {{ template "devfileregistry.fullname" . }}
           servicePort: 8080
-{{- if .Values.global.ingress.secretName }}
+{{- if and .Values.global.tlsEnabled .Values.global.ingress.secretName }}
   tls:
   - hosts:
     - {{ template "devfileregistry.hostname" . -}} . {{- .Values.global.ingress.domain }}

--- a/deploy/chart/devfile-registry/templates/route.yaml
+++ b/deploy/chart/devfile-registry/templates/route.yaml
@@ -12,7 +12,9 @@ spec:
     weight: 100
   port:
     targetPort: 8080
+  {{- if .Values.global.tlsEnabled }}
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect
+  {{- end -}}
 {{- end -}}

--- a/deploy/chart/devfile-registry/values.yaml
+++ b/deploy/chart/devfile-registry/values.yaml
@@ -13,6 +13,7 @@ global:
     domain: 192.168.2.1.nip.io
     secretName: ''
   isOpenShift: false
+  tlsEnabled: false
 
 devfileIndex:
   image: quay.io/devfile/devfile-index


### PR DESCRIPTION
**What does does this PR do / why we need it**:
Updates the TLS defaults for OpenShift to match what we have set for Kubernetes (optional at the moment). Also updates the readme to include a section on installing on OpenShift

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:
N/A

**How to test changes / Special notes to the reviewer**:
N/A