### PR TITLE
Update to newer Minikube action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,12 +58,12 @@ jobs:
       with:
         go-version: 1.13
     - name: Setup Minikube
-      uses: manusa/actions-setup-minikube@v2.3.1
+      uses: manusa/actions-setup-minikube@v2.4.2
       with:
-        minikube version: 'v1.16.0'
-        kubernetes version: 'v1.19.2'
+        minikube version: 'v1.21.0'
+        kubernetes version: 'v1.21.0'
         driver: 'docker'
-    - name: Enable ingress on Minikube
-      run: minikube addons enable ingress
+        github token: ${{ secrets.GITHUB_TOKEN }}
+        start args: '--addons=ingress'
     - name: Run the devfile registry integration tests
       run: .ci/run_tests_minikube_linux.sh


### PR DESCRIPTION
Updates to a newer version of the Minikube github action, which should hopefully fix the issues with ingress on the PR tests.