### PR TITLE
Fix index-generator error handling

### DIFF
--- a/index/generator/cmd/root.go
+++ b/index/generator/cmd/root.go
@@ -36,23 +36,25 @@ var force bool
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "generator <registry directory path> <index file path>",
-	Short: shortDesc,
-	Long:  longDesc,
-	Args:  cobra.ExactArgs(2),
-	Run: func(cmd *cobra.Command, args []string) {
+	Use:          "generator <registry directory path> <index file path>",
+	Short:        shortDesc,
+	Long:         longDesc,
+	Args:         cobra.ExactArgs(2),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
 		registryDirPath := args[0]
 		indexFilePath := args[1]
 
 		index, err := library.GenerateIndexStruct(registryDirPath, force)
 		if err != nil {
-			fmt.Printf("failed to generate index struct: %v", err)
+			return fmt.Errorf("failed to generate index struct: %v", err)
 		}
 
 		err = library.CreateIndexFile(index, indexFilePath)
 		if err != nil {
-			fmt.Printf("failed to create index file: %v", err)
+			return fmt.Errorf("failed to create index file: %v", err)
 		}
+		return nil
 	},
 }
 
@@ -60,7 +62,6 @@ var rootCmd = &cobra.Command{
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**What does does this PR do / why we need it**:
Fixes the error handling for the index-generator to properly return an error when it fails. I also added `SilenceUsage: true` to the command, as the command usage was showing every time the command failed which was cluttering the output. The command usage can still be shown with the `--help` flag.

I also removed the `fmt.Println` that we were doing when the command exited with an error, as Cobra already prints the error, so the error was getting printed twice.

```
johncollier@jcollier-mac generator % ./index-generator ~/exitcodetest/registry index.json
failed to generate index struct: java-maven devfile is not valid: apiVersion or schemaVersion not present in devfile
johncollier@jcollier-mac generator % echo $?
0
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/533