### PR TITLE
Support retrieving sample devfiles from index server

### DIFF
--- a/index/server/main.go
+++ b/index/server/main.go
@@ -63,6 +63,7 @@ var mediaTypeMapping = map[string]string{
 
 var (
 	stacksPath            = os.Getenv("DEVFILE_STACKS")
+	samplesPath           = os.Getenv("DEVFILE_SAMPLES")
 	indexPath             = os.Getenv("DEVFILE_INDEX")
 	base64IndexPath       = os.Getenv("DEVFILE_BASE64_INDEX")
 	sampleIndexPath       = os.Getenv("DEVFILE_SAMPLE_INDEX")
@@ -172,9 +173,18 @@ func main() {
 		name := c.Param("name")
 		for _, devfileIndex := range index {
 			if devfileIndex.Name == name {
-				bytes, err := pullStackFromRegistry(devfileIndex)
+				var bytes []byte
+				if devfileIndex.Type == indexSchema.StackDevfileType {
+					bytes, err = pullStackFromRegistry(devfileIndex)
+				} else {
+					// Retrieve the sample devfile stored under /registry/samples/<devfile>
+					sampleDevfilePath := path.Join(samplesPath, devfileIndex.Name, devfileName)
+					if _, err = os.Stat(sampleDevfilePath); err == nil {
+						bytes, err = ioutil.ReadFile(sampleDevfilePath)
+					}
+				}
+
 				if err != nil {
-					log.Fatal(err.Error())
 					c.JSON(http.StatusInternalServerError, gin.H{
 						"error":  err.Error(),
 						"status": fmt.Sprintf("failed to pull the devfile of %s", name),

--- a/index/server/main.go
+++ b/index/server/main.go
@@ -185,6 +185,7 @@ func main() {
 				}
 
 				if err != nil {
+					log.Print(err.Error())
 					c.JSON(http.StatusInternalServerError, gin.H{
 						"error":  err.Error(),
 						"status": fmt.Sprintf("failed to pull the devfile of %s", name),

--- a/tests/integration/pkg/tests/indexserver_tests.go
+++ b/tests/integration/pkg/tests/indexserver_tests.go
@@ -65,11 +65,25 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 		gomega.Expect(hasStacks && hasSamples).To(gomega.BeTrue())
 	})
 
-	ginkgo.It("/devfiles/<devfile> endpoint should return a devfile", func() {
+	ginkgo.It("/devfiles/<devfile> endpoint should return a devfile for stacks", func() {
 		parserArgs := parser.ParserArgs{
 			URL: config.Registry + "/devfiles/nodejs",
 		}
 		_, _, err := devfilePkg.ParseDevfileAndValidate(parserArgs)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("/devfiles/<devfile> endpoint should return a devfile for samples", func() {
+		parserArgs := parser.ParserArgs{
+			URL: config.Registry + "/devfiles/code-with-quarkus",
+		}
+		_, _, err := devfilePkg.ParseDevfileAndValidate(parserArgs)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
+
+	ginkgo.It("/devfiles/<devfile> endpoint should return an error for a devfile that doesn't exist", func() {
+		resp, err := http.Get(config.Registry + "/devfiles/fake-stack")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
 	})
 })


### PR DESCRIPTION
Signed-off-by: John Collier <jcollier@redhat.com>

**What does does this PR do / why we need it**:
This PR fixes the issue seen when requesting a sample's devfile from the `/devfiles/<id>` endpoint in the devfile registry index server where the server would crash. It also updates the endpoint to properly support retrieving sample devfiles now.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/549

**PR acceptance criteria**:

- [x] Test
