### PR TITLE
Fix workflow for pushing index server image

### DIFF
--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -19,17 +19,16 @@ jobs:
     steps:
     - name: Check out registry support source code
       uses: actions/checkout@v2
-    - name: Build and push devfile-index-base docker image
-      uses: docker/build-push-action@v1.1.0
+    - name: Login to Quay
+      uses: docker/login-action@v1 
       with:
-        path: ./index/server
+        registry: quay.io
         username: ${{ secrets.QUAY_USERNAME }}
         password: ${{ secrets.QUAY_PASSWORD }}
-        registry: quay.io
-        repository: devfile/devfile-index-base
-        dockerfile: ./index/server/Dockerfile
-        tags: next
-        tag_with_sha: true
+    - name: Build the index server base image
+      run: cd index/server && ./build.sh
+    - name: Push the index server base image
+      run: cd index/server && ./push.sh quay.io/devfile/devfile-index-base:next
 
   dispatch:
     needs: indexServerBuild


### PR DESCRIPTION
Due to changes in how we build the index server image with the viewer, the docker push action also needs to be updated