### PR TITLE
Updated pushimage-next workflow

### DIFF
--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -12,6 +12,8 @@ name: Next Dockerimage
 on:
   push:
     branches: [ main ]
+  repository_dispatch:
+    types: [build]
 
 jobs:
   indexServerBuild:


### PR DESCRIPTION
**Please specify the area for this PR**
registry-image

**What does does this PR do / why we need it**:
This allows the rebuild of the devfile registry when the `registry-viewer` repo is updated.

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/534

Related?
https://github.com/devfile/registry-viewer/pull/16