### PR TITLE
Add dispatch payload

### DIFF
--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -45,6 +45,7 @@ jobs:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: build
+          client-payload: '{"repo": "${{ github.event.repository.name }}", "sha": "${{ github.sha }}"}'
 
   ociRegistryBuild:
     runs-on: ubuntu-latest

--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -42,12 +42,20 @@ jobs:
       - name: Get the repository name and commit sha
         id: get_commit_info
         run: |
+          # Check if repository name is not set in the client payload
+          # If it's not set, the triggered commit came from this repo (registry-support)
+          # If it is set, the triggered commit came from registry-viewer
           if [ -z ${{ github.event.client_payload.repo }} ];
           then
             echo ::set-output name=repo::$(echo ${{ github.event.repository.name }})
           else
             echo ::set-output name=repo::$(echo ${{ github.event.client_payload.repo }})
           fi
+          
+          # Check if commit sha is not set in the client payload
+          # If it's not set, the triggered commit came from this repo (registry-support)
+          # If it is set, the triggered commit came from registry-viewer
+
           if [ -z ${{ github.event.client_payload.sha }} ];
           then
             echo ::set-output name=sha::$(echo ${{ github.sha }})

--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -39,13 +39,28 @@ jobs:
         repo: ['devfile/registry']
     runs-on: ubuntu-latest
     steps:
+      - name: Get the repository name and commit sha
+        id: get_commit_info
+        run: |
+          if [ -z ${{ github.event.client_payload.repo }} ];
+          then
+            echo ::set-output name=repo::$(echo ${{ github.event.repository.name }})
+          else
+            echo ::set-output name=repo::$(echo ${{ github.event.client_payload.repo }})
+          fi
+          if [ -z ${{ github.event.client_payload.sha }} ];
+          then
+            echo ::set-output name=sha::$(echo ${{ github.sha }})
+          else
+            echo ::set-output name=sha::$(echo ${{ github.event.client_payload.sha }})
+          fi
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v1
         with:
           token: ${{ secrets.REPO_ACCESS_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: build
-          client-payload: '{"repo": "${{ github.event.repository.name }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"repo": "${{ steps.get_commit_info.outputs.REPO }}", "sha": "${{ steps.get_commit_info.outputs.SHA }}"}'
 
   ociRegistryBuild:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For more information, please see https://github.com/devfile/api/issues/527

This PR updates the dispatch workflow that we have to include the following in its payload:
- Repository name
- Commit SHA

This enables us to include the repository name and commit sha in the commit messages that triggers the repository deploy to staging.

It first checks if the the repository name and commit sha already exist in the workflow's client payload. If so, that means the workflow was triggered from the registry-viewer repo, and we want to use its repo name and commit sha instead. If it doesn't exist, that means a commit in this repo is triggering the deploy and we want to use it instead.



