### PR TITLE
Telemetry on client side

### DIFF
--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -205,7 +205,11 @@ func PullStackByMediaTypesFromRegistry(registry string, stack string, allowedMed
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipTLSVerify},
 		},
 	}
-	resolver := docker.NewResolver(docker.ResolverOptions{PlainHTTP: plainHTTP, Client: httpClient})
+	headers := make(http.Header)
+	if user != "" {
+		headers.Add("User", user)
+	}
+	resolver := docker.NewResolver(docker.ResolverOptions{Headers: headers, PlainHTTP: plainHTTP, Client: httpClient})
 	ref := path.Join(urlObj.Host, stackIndex.Links["self"])
 	fileStore := content.NewFileStore(destDir)
 	defer fileStore.Close()


### PR DESCRIPTION
Signed-off-by: Jingfu Wang <jingfwan@redhat.com>

**Please specify the area for this PR**
Registry library

**What does does this PR do / why we need it**:
This PR adds header to registry library to support telemetry (download devfile user action) on client side. 

**Which issue(s) this PR fixes**:

Related issue: https://github.com/devfile/api/issues/281

**PR acceptance criteria**:

- [x] Test (WIP) 

- [x] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
Build registry library CLI then interact with community registry
