### PR TITLE
Update Ingress from extension to networking

### DIFF
--- a/deploy/chart/devfile-registry/templates/ingress.yaml
+++ b/deploy/chart/devfile-registry/templates/ingress.yaml
@@ -7,7 +7,7 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 {{- if not .Values.global.isOpenShift }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "devfileregistry.fullname" . }}
@@ -24,9 +24,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: {{ template "devfileregistry.fullname" . }}
-          servicePort: 8080
+          service:
+            name: {{ template "devfileregistry.fullname" . }}
+            port: 
+              number: 8080
 {{- if and .Values.global.tlsEnabled .Values.global.ingress.secretName }}
   tls:
   - hosts:


### PR DESCRIPTION
Signed-off-by: Maysun J Faisal <maysunaneek@gmail.com>

**Please specify the area for this PR**
registry deploy

**What does does this PR do / why we need it**:
Extension Ingress has been deprecated and needs to be updated to networking ingress

### Before the update:
```
$ helm install devfile-registry ./deploy/chart/devfile-registry --set global.ingress.domain="192.168.64.2.nip.io" --set devfileIndex.image=maysunfaisal/devfile-index --set devfileIndex.tag=latest
W0930 15:05:47.476253   89145 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
W0930 15:05:48.593295   89145 warnings.go:70] extensions/v1beta1 Ingress is deprecated in v1.14+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress
Error: Internal error occurred: failed calling webhook "validate.nginx.ingress.kubernetes.io": Post "https://ingress-nginx-controller-admission.ingress-nginx.svc:443/networking/v1beta1/ingresses?timeout=10s": dial tcp 10.102.202.207:443: connect: connection refused

```

```
$ helm install devfile-registry ./deploy/chart/devfile-registry --set global.ingress.domain="192.168.64.3.nip.io" --set devfileIndex.image=maysunfaisal/devfile-index --set devfileIndex.tag=latest
Error: unable to build kubernetes objects from release manifest: unable to recognize "": no matches for kind "Ingress" in version "extensions/v1beta1"
```

### After the update:
```
$ helm install devfile-registry ./deploy/chart/devfile-registry --set global.ingress.domain="192.168.64.3.nip.io" --set devfileIndex.image=maysunfaisal/devfile-index --set devfileIndex.tag=latest
NAME: devfile-registry
LAST DEPLOYED: Fri Oct  1 13:06:02 2021
NAMESPACE: maysun
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

```
NAME                                         CLASS     HOSTS                                         ADDRESS        PORTS     AGE
ingress.networking.k8s.io/devfile-registry   <none>    devfile-registry-maysun.192.168.64.3.nip.io   192.168.64.3   80        75s
```
```
$ curl http://devfile-registry-maysun.192.168.64.3.nip.io/health
{"message":"the server is up and running"}
```

**Which issue(s) this PR fixes**:
https://github.com/devfile/api/issues/636

**PR acceptance criteria**:

- [ ] Test (WIP) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
Use the chart 😄 