### PR TITLE
ignore registry viewer API events

### DIFF
--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -106,8 +106,9 @@ func serveDevfile(c *gin.Context) {
 				return
 			}
 
-			// Track event for telemetry
-			if enableTelemetry {
+			// Track event for telemetry.  Ignore events from the registry-viewer since those are tracked on the client side
+			if enableTelemetry && !util.IsRegistryViewerEvent(c) {
+
 				user := util.GetUser(c)
 				client := util.GetClient(c)
 
@@ -235,8 +236,8 @@ func buildIndexAPIResponse(c *gin.Context) {
 		c.File(responseIndexPath)
 	}
 
-	// Track event for telemetry
-	if enableTelemetry {
+	// Track event for telemetry.  Ignore events from the registry-viewer since those are tracked on the client side
+	if enableTelemetry && !util.IsRegistryViewerEvent(c) {
 		user := util.GetUser(c)
 		client := util.GetClient(c)
 		err := util.TrackEvent(analytics.Track{

--- a/index/server/pkg/server/index.go
+++ b/index/server/pkg/server/index.go
@@ -172,7 +172,8 @@ func ociServerProxy(c *gin.Context) {
 				resource = parts[3]
 			}
 
-			if resource == "blobs" {
+			//Ignore events from the registry-viewer since those are tracked on the client side
+			if resource == "blobs" && !util.IsRegistryViewerEvent(c) {
 				user := util.GetUser(c)
 				client := util.GetClient(c)
 

--- a/index/server/pkg/util/telemetry.go
+++ b/index/server/pkg/util/telemetry.go
@@ -11,6 +11,7 @@ import (
 const (
 	telemetryKey = "6HBMiy5UxBtsbxXx7O4n0t0u4dt8IAR3"
 	defaultUser  = "devfile-registry"
+	viewerId     = "registry-viewer"
 )
 
 //TrackEvent tracks event for telemetry
@@ -92,4 +93,14 @@ func getRegion(c *gin.Context) string {
 		return defaultRegion
 	}
 
+}
+
+//IsRegistryViewerEvent determines if the event is coming from the registry viewer client
+func IsRegistryViewerEvent(c *gin.Context) bool {
+	client := GetClient(c)
+	if client == viewerId {
+		return true
+	}
+
+	return false
 }

--- a/index/server/pkg/util/telemetry_test.go
+++ b/index/server/pkg/util/telemetry_test.go
@@ -231,3 +231,65 @@ func TestSetContext(t *testing.T) {
 		})
 	}
 }
+
+func TestIsRegistryViewerEvent(t *testing.T) {
+	tests := []struct {
+		name    string
+		context *gin.Context
+		want    bool
+	}{
+		{
+			name: "Test registry-viewer event",
+			context: &gin.Context{
+				Request: &http.Request{
+					Header: http.Header{
+						"Client": {"registry-viewer"},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Test non registry-viewer event",
+			context: &gin.Context{
+				Request: &http.Request{
+					Header: http.Header{
+						"Client": {"odo"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Test unset client header",
+			context: &gin.Context{
+				Request: &http.Request{
+					Header: http.Header{
+						"User": {"registry-viewer"},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Test case-sensitivity",
+			context: &gin.Context{
+				Request: &http.Request{
+					Header: http.Header{
+						"Client": {"REGISTRY-viewer"},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := IsRegistryViewerEvent(test.context)
+			if got != test.want {
+				t.Errorf("Got: %v, Expected: %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Please specify the area for this PR**
registry

**What does does this PR do / why we need it**:
Avoids collecting telemetry on the server side API calls since they are a duplication of the client side events

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/696

**PR acceptance criteria**:

- [x] Test (WIP) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
Created a build image and deployed locally on crc, using the Test segment instance.  Verified no API events from the viewer were being sent.  
