### PR TITLE
Access-Control-Allow-Origin header added to `/index*` routes

### DIFF
--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -50,8 +50,6 @@ func serveDevfileIndex(c *gin.Context) {
 
 // serveDevfileIndexWithType returns the index file content with specific devfile type
 func serveDevfileIndexWithType(c *gin.Context) {
-	// Set headers
-	c.Header("Access-Control-Allow-Origin", "*")
 
 	// Serve the index with type
 	buildIndexAPIResponse(c)
@@ -169,6 +167,9 @@ func buildIndexAPIResponse(c *gin.Context) {
 	var bytes []byte
 	var responseIndexPath, responseBase64IndexPath string
 	isFiltered := false
+
+	// Sets Access-Control-Allow-Origin response header to allow cross origin requests
+	c.Header("Access-Control-Allow-Origin", "*")
 
 	// Load the appropriate index file name based on the devfile type
 	switch indexType {

--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -50,6 +50,8 @@ func serveDevfileIndex(c *gin.Context) {
 
 // serveDevfileIndexWithType returns the index file content with specific devfile type
 func serveDevfileIndexWithType(c *gin.Context) {
+	// Set headers
+	c.Header("Access-Control-Allow-Origin", "*")
 
 	// Serve the index with type
 	buildIndexAPIResponse(c)


### PR DESCRIPTION
**Please specify the area for this PR**

registry-support/server/index

**What does does this PR do / why we need it**:

Adds the `Access-Control-Allow-Origin: *` header to response of `/index/:type`. Without this will cause a CORS error in the case specified in the linked issue.

**Which issue(s) this PR fixes**:

[devfile/api#719](https://github.com/devfile/api/issues/719)

**PR acceptance criteria**:

- [ ] Test (WIP) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
