### PR TITLE
Suppress devconsole events

### DIFF
--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -106,8 +106,8 @@ func serveDevfile(c *gin.Context) {
 				return
 			}
 
-			// Track event for telemetry.  Ignore events from the registry-viewer since those are tracked on the client side
-			if enableTelemetry && !util.IsRegistryViewerEvent(c) {
+			// Track event for telemetry.  Ignore events from the registry-viewer and DevConsole since those are tracked on the client side
+			if enableTelemetry && !util.IsWebClient(c) {
 
 				user := util.GetUser(c)
 				client := util.GetClient(c)
@@ -239,8 +239,8 @@ func buildIndexAPIResponse(c *gin.Context) {
 		c.File(responseIndexPath)
 	}
 
-	// Track event for telemetry.  Ignore events from the registry-viewer since those are tracked on the client side
-	if enableTelemetry && !util.IsRegistryViewerEvent(c) {
+	// Track event for telemetry.  Ignore events from the registry-viewer and DevConsole since those are tracked on the client side
+	if enableTelemetry && !util.IsWebClient(c) {
 		user := util.GetUser(c)
 		client := util.GetClient(c)
 		err := util.TrackEvent(analytics.Track{

--- a/index/server/pkg/server/index.go
+++ b/index/server/pkg/server/index.go
@@ -172,8 +172,8 @@ func ociServerProxy(c *gin.Context) {
 				resource = parts[3]
 			}
 
-			//Ignore events from the registry-viewer since those are tracked on the client side
-			if resource == "blobs" && !util.IsRegistryViewerEvent(c) {
+			//Ignore events from the registry-viewer and DevConsole since those are tracked on the client side
+			if resource == "blobs" && !util.IsWebClient(c) {
 				user := util.GetUser(c)
 				client := util.GetClient(c)
 

--- a/index/server/pkg/util/telemetry.go
+++ b/index/server/pkg/util/telemetry.go
@@ -12,6 +12,7 @@ const (
 	telemetryKey = "6HBMiy5UxBtsbxXx7O4n0t0u4dt8IAR3"
 	defaultUser  = "devfile-registry"
 	viewerId     = "registry-viewer"
+	consoleId    = "openshift-console"
 )
 
 //TrackEvent tracks event for telemetry
@@ -95,10 +96,10 @@ func getRegion(c *gin.Context) string {
 
 }
 
-//IsRegistryViewerEvent determines if the event is coming from the registry viewer client
-func IsRegistryViewerEvent(c *gin.Context) bool {
+//IsWebClient determines if the event is coming from the registry viewer or DevConsole client.
+func IsWebClient(c *gin.Context) bool {
 	client := GetClient(c)
-	if client == viewerId {
+	if client == viewerId || client == consoleId {
 		return true
 	}
 

--- a/index/server/pkg/util/telemetry_test.go
+++ b/index/server/pkg/util/telemetry_test.go
@@ -243,7 +243,18 @@ func TestIsRegistryViewerEvent(t *testing.T) {
 			context: &gin.Context{
 				Request: &http.Request{
 					Header: http.Header{
-						"Client": {"registry-viewer"},
+						"Client": {viewerId},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Test openshift-console event",
+			context: &gin.Context{
+				Request: &http.Request{
+					Header: http.Header{
+						"Client": {consoleId},
 					},
 				},
 			},
@@ -265,7 +276,7 @@ func TestIsRegistryViewerEvent(t *testing.T) {
 			context: &gin.Context{
 				Request: &http.Request{
 					Header: http.Header{
-						"User": {"registry-viewer"},
+						"User": {viewerId},
 					},
 				},
 			},
@@ -286,7 +297,7 @@ func TestIsRegistryViewerEvent(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := IsRegistryViewerEvent(test.context)
+			got := IsWebClient(test.context)
 			if got != test.want {
 				t.Errorf("Got: %v, Expected: %v", got, test.want)
 			}


### PR DESCRIPTION
Ignore telemetry from devconsole, server side API calls

**Please specify the area for this PR**
/area telemetry

**What does does this PR do / why we need it**:
We are collecting a lot of events that do not give us insights into our client behaviour.  We should reduce the noise and  costs with sending unnecessary events.

**Which issue(s) this PR fixes**:


Fixes #?
https://github.com/devfile/api/issues/736

**PR acceptance criteria**:

- [x] Test (WIP) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
- updated the Segment write key to point to the test registry instance
- ran the build script, tagged the image and uploaded it to quay
- deployed the new image on a local crc cluster
- updated devconsole code to point to local registry server and navigated to the devfile samples page.  Verified the "list samples" events were not sent to Segment.
