### PR TITLE
Fix telemetry on  integration tests 

### DIFF
--- a/deploy/chart/devfile-registry/values.yaml
+++ b/deploy/chart/devfile-registry/values.yaml
@@ -33,4 +33,4 @@ persistence:
 
 telemetry:
   enabled: "false"
-  registryName: "anonymous" 
+  registryName: "devfile-registry"

--- a/index/server/pkg/server/constants.go
+++ b/index/server/pkg/server/constants.go
@@ -37,5 +37,5 @@ var (
 	stackIndexPath        = os.Getenv("DEVFILE_STACK_INDEX")
 	stackBase64IndexPath  = os.Getenv("DEVFILE_STACK_BASE64_INDEX")
 	enableTelemetry       = util.GetOptionalEnv("ENABLE_TELEMETRY", false).(bool)
-	registry              = util.GetOptionalEnv("REGISTRY_NAME", "anonymous")
+	registry              = util.GetOptionalEnv("REGISTRY_NAME", "devfile-registry")
 )

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -18,4 +18,4 @@ RUN cd /registry-test/registry-library && ./build.sh && cp /registry-test/regist
 # Build the test binary
 RUN /registry-test/build.sh
 
-CMD /registry-test/devfileregistry-integration
+CMD /registry-test/devfile-registry-integration

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -31,4 +31,6 @@ To run the tests locally, you must make sure that the CLI version of the `regist
 2. Run the `build.sh` script in that folder
 3. Run `cp registry-library /usr/local/bin/registry-library` to add it to your system path
 
-Then, to run the tests, navigate back to the `tests/integration` folder and run `export REGISTRY=$REGISTRY ./devfile-registry-integration` to run the tests, where `$REGISTRY` is the hostname of the devfile registry that you wish to test against (such as https://registry.devfile.io or http://devfile-registry-default.10.101.108.46.nip.io).
+Then, to run the tests, navigate back to the `tests/integration` folder and run:
+1. `export REGISTRY=$REGISTRY` where `$REGISTRY` is the hostname of the devfile registry that you wish to test against (such as https://registry.stage.devfile.io or http://devfile-registry-default.10.101.108.46.nip.io).
+2. `./devfile-registry-integration` to run the tests 

--- a/tests/integration/build.sh
+++ b/tests/integration/build.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-CGO_ENABLED=0 go test -v -c -o devfileregistry-integration ./cmd/devfileregistry_test.go
+CGO_ENABLED=0 go test -v -c -o devfile-registry-integration ./cmd/devfileregistry_test.go

--- a/tests/integration/cmd/devfileregistry_test.go
+++ b/tests/integration/cmd/devfileregistry_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/onsi/gomega"
 )
 
-// Integration/e2e test logic based on https://github.com/devfile/devworkspace-operator/tree/master/test/e2e
+// Integration/e2e test logic based on https://github.com/devfile/devworkspace-operator/tree/main/test/e2e
 
 //Create Constant file
 const (
@@ -41,7 +41,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 		registry = "https://registry.devfile.io"
 	}
 	config.Registry = registry
-	config.RegistryList = registry + "," + "https://registry.devfile.io"
+	config.RegistryList = registry + "," + "https://registry.stage.devfile.io"
 	os.Setenv("REGISTRY_LIST", config.RegistryList)
 
 	config.IsTestRegistry, _ = strconv.ParseBool(os.Getenv("IS_TEST_REGISTRY"))

--- a/tests/integration/go.sum
+++ b/tests/integration/go.sum
@@ -86,8 +86,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/devfile/api/v2 v2.0.0-20210910153124-da620cd1a7a1 h1:k25KKenebyxOUnGmGTZE0F/wHDQ+fh+HoxVfjsKXNv0=
 github.com/devfile/api/v2 v2.0.0-20210910153124-da620cd1a7a1/go.mod h1:kLX/nW93gigOHXK3NLeJL2fSS/sgEe+OHu8bo3aoOi4=
+github.com/devfile/api/v2 v2.0.0-20211021164004-dabee4e633ed h1:OXF9l+MlJrirXAqKN6EZUVaHB0FKm7nh0EjpktwnBig=
+github.com/devfile/api/v2 v2.0.0-20211021164004-dabee4e633ed/go.mod h1:d99eTN6QxgzihOOFyOZA+VpUyD4Q1pYRYHZ/ci9J96Q=
 github.com/devfile/library v1.1.1-0.20210910214722-7c5ff63711ec h1:UtJiFJfnC7fhup2MbGOzt6DCKMFKJTw47aHHETLfcZA=
 github.com/devfile/library v1.1.1-0.20210910214722-7c5ff63711ec/go.mod h1:svPWwWb+BP15SXCHl0dyOeE4Sohrjl5a2BaOzc/riLc=
+github.com/devfile/library v1.2.1-0.20211104222135-49d635cb492f h1:kKsBWkFiD7tSIpzwfmz7TH89U1U3yRxSJ9UPOo2OH1s=
+github.com/devfile/library v1.2.1-0.20211104222135-49d635cb492f/go.mod h1:uFZZdTuRqA68FVe/JoJHP92CgINyQkyWnM2Qyiim+50=
 github.com/devfile/registry-support/index/generator v0.0.0-20210916150157-08b31e03fdf0 h1:F2OkuW0ASrSz5d06tJxWfweUNYTnsOCyiGTEORisokE=
 github.com/devfile/registry-support/index/generator v0.0.0-20210916150157-08b31e03fdf0/go.mod h1:bLGagbW2SFn7jo5+kUPlCMehIGqWkRtLKc5O0OyJMJM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/tests/integration/pkg/tests/devfilelibrary_tests.go
+++ b/tests/integration/pkg/tests/devfilelibrary_tests.go
@@ -45,7 +45,7 @@ var _ = ginkgo.BeforeEach(func() {
 	publicDevfileRegistry = strings.Split(config.RegistryList, ",")[1]
 })
 
-// Integration/e2e test logic based on https://github.com/devfile/registry-operator/tree/master/test/integration
+// Integration/e2e test logic based on https://github.com/devfile/registry-operator/tree/main/tests/integration
 // Tests use the CLI version of the registry-library to test.
 // Note: Requires adding the CLI to the system path before running these tests
 var _ = ginkgo.Describe("[Verify registry library works with registry]", func() {


### PR DESCRIPTION
- Run integration tests against staging server
- Update stale URLs and registry client name
- Update local test run instructions and binary name

Signed-off-by: Kim Tsao <ktsao@redhat.com>

**Please specify the area for this PR**
/area telemetry

**What does does this PR do / why we need it**:

Unnecessary telemetry is being sent each time our integration tests are run 

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/742

**PR acceptance criteria**:

- [ ] Test (WIP) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:

Let the integration tests run in our GH action and verify telemetry is **not** being sent in our Woopra instance from the user `user`
