### PR TITLE
Update scripts to work with podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Issue tracking repo: https://github.com/devfile/api with label area/registry
 
 ## Build
 
+If you want to run the build scripts with Podman, set the environment variable
+`export USE_PODMAN=true`
+
 To build all of the components together (recommended) for dev/test, run `./build_registry.sh` to build a Devfile Registry index image that is populated with the mock devfile registry data under `tests/registry/`.
 
 Once the container has been pushed, you can push it to a container registry of your choosing with the following commands:

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,4 +1,4 @@
-# Troubelshooting the Devfile Registry
+# Troubleshooting the Devfile Registry
 
 ## Collecting Logs
 

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -1,5 +1,6 @@
+#!/bin/bash
 #
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2022 Red Hat, Inc.
 # This program and the accompanying materials are made
 # available under the terms of the Eclipse Public License 2.0
 # which is available at https://www.eclipse.org/legal/epl-2.0/
@@ -7,10 +8,6 @@
 # SPDX-License-Identifier: EPL-2.0
 #
 
-#!/bin/bash
-
-# Enable extended globbing in the shell
-shopt -s extglob
 
 buildToolsFolder="$(dirname "$0")"
 generatorFolder=$buildToolsFolder/../index/generator

--- a/build_registry.sh
+++ b/build_registry.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 # This script builds a devfile registry index container image based on the mock devfile registry data under tests/registry
 # This can be useful if developing components within this repository (such as the index server or build tools)
 # and want to test all of the components together
-
+shopt -s expand_aliases
 set -eux
 #set the docker alias if necessary
 . ./setenv.sh

--- a/build_registry.sh
+++ b/build_registry.sh
@@ -4,7 +4,7 @@
 # This can be useful if developing components within this repository (such as the index server or build tools)
 # and want to test all of the components together
 
-set -eu
+set -eux
 #set the docker alias if necessary
 . setenv.sh
 

--- a/build_registry.sh
+++ b/build_registry.sh
@@ -6,10 +6,10 @@
 
 set -eux
 #set the docker alias if necessary
-. setenv.sh
+. ./setenv.sh
 
 # Build the index server base image
-. index/server/build.sh
+. ./index/server/build.sh
 
 # Build the test devfile registry image
 docker build -t devfile-index:latest -f .ci/Dockerfile .

--- a/build_registry.sh
+++ b/build_registry.sh
@@ -4,10 +4,12 @@
 # This can be useful if developing components within this repository (such as the index server or build tools)
 # and want to test all of the components together
 
-set -eux
+set -eu
+#set the docker alias if necessary
+. setenv.sh
 
 # Build the index server base image
-./index/server/build.sh
+. index/server/build.sh
 
 # Build the test devfile registry image
 docker build -t devfile-index:latest -f .ci/Dockerfile .

--- a/index/server/build.sh
+++ b/index/server/build.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 # Build the index container for the registry
-buildfolder="$(realpath $(dirname $0))"
+buildfolder="$(realpath $(dirname ${BASH_SOURCE[0]}))"
 
 # Clone the registry-support repo
 if [ -d $buildfolder/registry-viewer ]; then

--- a/setenv.sh
+++ b/setenv.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script aliases the docker cli if the environment variable USE_PODMAN is set to true.
+
+# default value is false if USE_PODMAN is unset or null
+podman=${USE_PODMAN:-false}
+if [ ${podman} == true ]; then
+  alias docker=podman
+  echo "setting alias docker=podman"
+fi

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -3,6 +3,8 @@
 This folder contains the integration tests for the OCI-based Devfile Registry. The tests can be run against either a remote devfile registry (such as https://registry.stage.devfile.io), or a local devfile registry running your machine (such as in Minikube, or Docker Desktop).
 
 ## Build
+If you want to run the build scripts with Podman, set the environment variable
+`export USE_PODMAN=true`
 
 The integration tests can be built to either run in a Docker container, or locally on your machine.
 

--- a/tests/integration/docker-build.sh
+++ b/tests/integration/docker-build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+#set the docker alias if necessary
+. ../../setenv.sh
 # Get the registry-library
 cp -rf ../../registry-library ./
 

--- a/tests/integration/docker-push.sh
+++ b/tests/integration/docker-push.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
+
+#set the docker alias if necessary
+. ../../setenv.sh
+
 IMAGE_TAG=$1
 docker tag devfile-registry-integration $IMAGE_TAG
 docker push $IMAGE_TAG


### PR DESCRIPTION
**Please specify the area for this PR**
/area registry

**What does does this PR do / why we need it**:
Updates the scripts and READMEs to use podman as an alternative.  In order to have the alias command to run consistently, I had to source the scripts in ./build_registry.sh so they would all run under the same shell.


**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/766

**PR acceptance criteria**:

- [x] Test (WIP) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:

set the environment variable USE_PODMAN=true and run the main build script ./build_registry.sh