### PR TITLE
Update telemetry enablement

### DIFF
--- a/deploy/chart/devfile-registry/README.md
+++ b/deploy/chart/devfile-registry/README.md
@@ -77,3 +77,4 @@ The following fields can be configured in the Helm chart, either via the `values
 | `ociRegistry.memoryLimit`              | Memory for oci registry container               | `256Mi` |
 | `persistence.enabled`                  | Enable persistent storage for the registry      | `true` |
 | `persistence.size`                     | The size of the persistent volume (if-enabled)  | `1Gi` |
+| `telemetry.key`                        | The write key for the Segment instance          | **MUST BE SET BY USER**  |

--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -91,10 +91,10 @@ spec:
         env:
           - name: DEVFILE_VIEWER_ROOT
             value: "/viewer"
-          - name: ENABLE_TELEMETRY
-            value: {{ .Values.telemetry.enabled | quote }}
           - name: REGISTRY_NAME
             value: {{ .Values.telemetry.registryName }}
+          - name: TELEMETRY_KEY
+            value: {{ .Values.telemetry.key }}
         volumeMounts:
         - name: viewer-config
           mountPath: "/app/config"

--- a/deploy/chart/devfile-registry/values.yaml
+++ b/deploy/chart/devfile-registry/values.yaml
@@ -32,5 +32,5 @@ persistence:
   size: 1Gi
 
 telemetry:
-  enabled: "false"
   registryName: "devfile-registry"
+  key: "6HBMiy5UxBtsbxXx7O4n0t0u4dt8IAR3"

--- a/deploy/chart/devfile-registry/values.yaml
+++ b/deploy/chart/devfile-registry/values.yaml
@@ -33,4 +33,3 @@ persistence:
 
 telemetry:
   registryName: "devfile-registry"
-  key: "6HBMiy5UxBtsbxXx7O4n0t0u4dt8IAR3"

--- a/index/server/pkg/server/constants.go
+++ b/index/server/pkg/server/constants.go
@@ -36,6 +36,6 @@ var (
 	sampleBase64IndexPath = os.Getenv("DEVFILE_SAMPLE_BASE64_INDEX")
 	stackIndexPath        = os.Getenv("DEVFILE_STACK_INDEX")
 	stackBase64IndexPath  = os.Getenv("DEVFILE_STACK_BASE64_INDEX")
-	enableTelemetry       = util.GetOptionalEnv("ENABLE_TELEMETRY", false).(bool)
+	enableTelemetry       = util.IsTelemetryEnabled()
 	registry              = util.GetOptionalEnv("REGISTRY_NAME", "devfile-registry")
 )

--- a/index/server/pkg/util/telemetry.go
+++ b/index/server/pkg/util/telemetry.go
@@ -9,11 +9,12 @@ import (
 )
 
 const (
-	telemetryKey = "6HBMiy5UxBtsbxXx7O4n0t0u4dt8IAR3"
-	defaultUser  = "devfile-registry"
-	viewerId     = "registry-viewer"
-	consoleId    = "openshift-console"
+	defaultUser = "devfile-registry"
+	viewerId    = "registry-viewer"
+	consoleId   = "openshift-console"
 )
+
+var telemetryKey = GetOptionalEnv("TELEMETRY_KEY", "").(string)
 
 //TrackEvent tracks event for telemetry
 func TrackEvent(event analytics.Message) error {

--- a/index/server/pkg/util/util.go
+++ b/index/server/pkg/util/util.go
@@ -175,3 +175,10 @@ func ConvertToOldIndexFormat(schemaList []indexSchema.Schema) []indexSchema.Sche
 	}
 	return oldSchemaList
 }
+
+func IsTelemetryEnabled() bool {
+	if len(telemetryKey) > 0 {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Signed-off-by: Kim Tsao <ktsao@redhat.com>

**Please specify the area for this PR**
Removes the hardcoded segment write key

**What does does this PR do / why we need it**:
We do not want to be collecting telemetry from users who set up their own devfile registries (per CNCF telemetry data policy).  They should be sending telemetry to their own Segment instance

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/769

**PR acceptance criteria**:

- [x] Test (WIP) 

- [ ] Documentation (WIP)

**How to test changes / Special notes to the reviewer**:
