### PR TITLE
Change to slug of the `download-starter-project` endpoint

### DIFF
--- a/index/server/pkg/server/index.go
+++ b/index/server/pkg/server/index.go
@@ -136,8 +136,8 @@ func ServeRegistry() {
 	router.GET("/health", serveHealthCheck)
 	router.GET("/devfiles/:name", serveDevfile)
 	router.GET("/devfiles/:name/:version", serveDevfileWithVersion)
-	router.GET("/devfiles/:name/starterProjects/:starterProjectName", serveDevfileStarterProject)
-	router.GET("/devfiles/:name/:version/starterProjects/:starterProjectName", serveDevfileStarterProjectWithVersion)
+	router.GET("/devfiles/:name/starter-projects/:starterProjectName", serveDevfileStarterProject)
+	router.GET("/devfiles/:name/:version/starter-projects/:starterProjectName", serveDevfileStarterProjectWithVersion)
 
 	// Registry REST APIs for index v2
 	router.GET("/v2index", serveDevfileIndexV2)

--- a/index/server/registry-REST-API.adoc
+++ b/index/server/registry-REST-API.adoc
@@ -2032,7 +2032,7 @@ Note: Only provides download as the response, not the devfile content.
 === HTTP Request
 [source]
 ----
-GET http://{registry host}/devfiles/{stack}/starterProjects/{starterProject}
+GET http://{registry host}/devfiles/{stack}/starter-projects/{starterProject}
 ----
 
 === Request Parameters
@@ -2058,7 +2058,7 @@ The request body must be empty.
 === Request example
 [source]
 ----
-curl http://devfile-registry.192.168.1.1.nip.io/devfiles/nodejs/starterProjects/nodejs-starter -o nodejs-starter.zip
+curl http://devfile-registry.192.168.1.1.nip.io/devfiles/nodejs/starter-projects/nodejs-starter -o nodejs-starter.zip
 ----
 
 === Response example
@@ -2078,7 +2078,7 @@ Note: Only provides download as the response, not the devfile content.
 === HTTP Request
 [source]
 ----
-GET http://{registry host}/devfiles/{stack}/{version}/starterProjects/{starterProject}
+GET http://{registry host}/devfiles/{stack}/{version}/starter-projects/{starterProject}
 ----
 
 === Request Parameters
@@ -2107,7 +2107,7 @@ The request body must be empty.
 === Request example
 [source]
 ----
-curl http://devfile-registry.192.168.1.1.nip.io/devfiles/nodejs/1.0.1/starterProjects/nodejs-starter -o nodejs-starter.zip
+curl http://devfile-registry.192.168.1.1.nip.io/devfiles/nodejs/1.0.1/starter-projects/nodejs-starter -o nodejs-starter.zip
 ----
 
 === Response example

--- a/tests/integration/pkg/tests/indexserver_tests.go
+++ b/tests/integration/pkg/tests/indexserver_tests.go
@@ -284,8 +284,8 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 		}
 	})
 
-	ginkgo.It("/devfiles/<devfile>/starterProjects/<starterProject> endpoint should return a zip archive for devfile starter project", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/java-maven/starterProjects/springbootproject")
+	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return a zip archive for devfile starter project", func() {
+		resp, err := http.Get(config.Registry + "/devfiles/java-maven/starter-projects/springbootproject")
 		var bytes []byte
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -301,8 +301,8 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 		}))
 	})
 
-	ginkgo.It("/devfiles/<devfile>/<version>/starterProjects/<starterProject> endpoint should return a zip archive for devfile starter project", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/java-maven/latest/starterProjects/springbootproject")
+	ginkgo.It("/devfiles/<devfile>/<version>/starter-projects/<starterProject> endpoint should return a zip archive for devfile starter project", func() {
+		resp, err := http.Get(config.Registry + "/devfiles/java-maven/latest/starter-projects/springbootproject")
 		var bytes []byte
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -318,15 +318,15 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 		}))
 	})
 
-	ginkgo.It("/devfiles/<devfile>/starterProjects/<starterProject> endpoint should return an error for a devfile that doesn't exist", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/fake-stack/starterProjects/springbootproject")
+	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an error for a devfile that doesn't exist", func() {
+		resp, err := http.Get(config.Registry + "/devfiles/fake-stack/starter-projects/springbootproject")
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
 	})
 
-	ginkgo.It("/devfiles/<devfile>/starterProjects/<starterProject> endpoint should return an error for a starter project that doesn't exist", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/java-maven/starterProjects/fake-project")
+	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an error for a starter project that doesn't exist", func() {
+		resp, err := http.Get(config.Registry + "/devfiles/java-maven/starter-projects/fake-project")
 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**
registry server

**What does does this PR do / why we need it**:

Changes part of the endpoint's slug from `starterProjects/<starterProjectName>` to `starter-projects/<starterProjectName>` to better follow URL naming standards. This change also unblocks devfile/api#781.

Effects previous issues:
- devfile/api#720
- devfile/api#838

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#865

**PR acceptance criteria**:

- [ ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
