### PR TITLE
Skip offline test cases for registry acceptance tests

### DIFF
--- a/tests/integration/pkg/tests/indexserver_tests.go
+++ b/tests/integration/pkg/tests/indexserver_tests.go
@@ -373,23 +373,36 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 	})
 
 	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an error for an offline starter project file location that doesn't exist", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/java-maven/starter-projects/springbootproject-offline")
+		if config.IsTestRegistry {
+			resp, err := http.Get(config.Registry + "/devfiles/java-maven/starter-projects/springbootproject-offline")
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusInternalServerError))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusInternalServerError))
+		} else {
+			ginkgo.Skip("cannot guarantee test outside of test registry, skipping test")
+		}
 	})
 
 	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an error for a devfile that doesn't exist", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/fake-stack/starter-projects/springbootproject")
+		if config.IsTestRegistry {
+			resp, err := http.Get(config.Registry + "/devfiles/fake-stack/starter-projects/springbootproject")
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
+		} else {
+			ginkgo.Skip("cannot guarantee test outside of test registry, skipping test")
+		}
+
 	})
 
 	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an error for a starter project that doesn't exist", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/java-maven/starter-projects/fake-project")
+		if config.IsTestRegistry {
+			resp, err := http.Get(config.Registry + "/devfiles/java-maven/starter-projects/fake-project")
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
+		} else {
+			ginkgo.Skip("cannot guarantee test outside of test registry, skipping test")
+		}
 	})
 })


### PR DESCRIPTION
These test cases will have test data that won't be available when we run these as part of the acceptance tests in staging. So skipping them for now