### PR TITLE
Add CI check for tests against staging 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,3 +67,20 @@ jobs:
         start args: '--addons=ingress'
     - name: Run the devfile registry integration tests
       run: .ci/run_tests_minikube_linux.sh
+
+  test_staging:
+    name: Test Staging Devfile Registry
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Setup Go environment
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+    - name: Run the devfile registry integration tests
+      run: |
+        # Run the integration tests
+        cd tests/integration
+        ./docker-build.sh
+        docker run --env REGISTRY=https://registry.stage.devfile.io --env IS_TEST_REGISTRY=false devfile-registry-integration

--- a/tests/integration/pkg/tests/indexserver_tests.go
+++ b/tests/integration/pkg/tests/indexserver_tests.go
@@ -322,54 +322,68 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 	})
 
 	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an offline zip archive for devfile starter project", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/go/starter-projects/go-starter-offline")
-		var bytes []byte
+		if config.IsTestRegistry {
+			resp, err := http.Get(config.Registry + "/devfiles/go/starter-projects/go-starter-offline")
+			var bytes []byte
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		defer resp.Body.Close()
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer resp.Body.Close()
 
-		bytes, err = ioutil.ReadAll(resp.Body)
+			bytes, err = ioutil.ReadAll(resp.Body)
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
-		gomega.Expect(bytes).ToNot(gomega.BeEmpty())
-		gomega.Expect(bytes).To(gomega.Satisfy(func(file []byte) bool {
-			return http.DetectContentType(file) == "application/zip"
-		}))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
+			gomega.Expect(bytes).ToNot(gomega.BeEmpty())
+			gomega.Expect(bytes).To(gomega.Satisfy(func(file []byte) bool {
+				return http.DetectContentType(file) == "application/zip"
+			}))
+		} else {
+			ginkgo.Skip("cannot guarantee test outside of test registry, skipping test")
+		}
 	})
 
 	ginkgo.It("/devfiles/<devfile>/<version>/starter-projects/<starterProject> endpoint should return an offline zip archive for devfile starter project", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/go/1.2.0/starter-projects/go-starter-offline")
-		var bytes []byte
+		if config.IsTestRegistry {
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		defer resp.Body.Close()
+			resp, err := http.Get(config.Registry + "/devfiles/go/1.2.0/starter-projects/go-starter-offline")
+			var bytes []byte
 
-		bytes, err = ioutil.ReadAll(resp.Body)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer resp.Body.Close()
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
-		gomega.Expect(bytes).ToNot(gomega.BeEmpty())
-		gomega.Expect(bytes).To(gomega.Satisfy(func(file []byte) bool {
-			return http.DetectContentType(file) == "application/zip"
-		}))
+			bytes, err = ioutil.ReadAll(resp.Body)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
+			gomega.Expect(bytes).ToNot(gomega.BeEmpty())
+			gomega.Expect(bytes).To(gomega.Satisfy(func(file []byte) bool {
+				return http.DetectContentType(file) == "application/zip"
+			}))
+		} else {
+			ginkgo.Skip("cannot guarantee test outside of test registry, skipping test")
+		}
 	})
 
 	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an offline zip archive of a subdir for devfile starter project", func() {
-		resp, err := http.Get(config.Registry + "/devfiles/java-quarkus/starter-projects/community-offline")
-		var bytes []byte
+		if config.IsTestRegistry {
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		defer resp.Body.Close()
+			resp, err := http.Get(config.Registry + "/devfiles/java-quarkus/starter-projects/community-offline")
+			var bytes []byte
 
-		bytes, err = ioutil.ReadAll(resp.Body)
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			defer resp.Body.Close()
 
-		gomega.Expect(err).NotTo(gomega.HaveOccurred())
-		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
-		gomega.Expect(bytes).ToNot(gomega.BeEmpty())
-		gomega.Expect(bytes).To(gomega.Satisfy(func(file []byte) bool {
-			return http.DetectContentType(file) == "application/zip"
-		}))
+			bytes, err = ioutil.ReadAll(resp.Body)
+
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusAccepted))
+			gomega.Expect(bytes).ToNot(gomega.BeEmpty())
+			gomega.Expect(bytes).To(gomega.Satisfy(func(file []byte) bool {
+				return http.DetectContentType(file) == "application/zip"
+			}))
+		} else {
+			ginkgo.Skip("cannot guarantee test outside of test registry, skipping test")
+		}
 	})
 
 	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an error for an offline starter project file location that doesn't exist", func() {
@@ -384,25 +398,18 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 	})
 
 	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an error for a devfile that doesn't exist", func() {
-		if config.IsTestRegistry {
-			resp, err := http.Get(config.Registry + "/devfiles/fake-stack/starter-projects/springbootproject")
+		resp, err := http.Get(config.Registry + "/devfiles/fake-stack/starter-projects/springbootproject")
 
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
-		} else {
-			ginkgo.Skip("cannot guarantee test outside of test registry, skipping test")
-		}
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
 
 	})
 
 	ginkgo.It("/devfiles/<devfile>/starter-projects/<starterProject> endpoint should return an error for a starter project that doesn't exist", func() {
-		if config.IsTestRegistry {
-			resp, err := http.Get(config.Registry + "/devfiles/java-maven/starter-projects/fake-project")
 
-			gomega.Expect(err).NotTo(gomega.HaveOccurred())
-			gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
-		} else {
-			ginkgo.Skip("cannot guarantee test outside of test registry, skipping test")
-		}
+		resp, err := http.Get(config.Registry + "/devfiles/java-maven/starter-projects/fake-project")
+
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(resp.StatusCode).To(gomega.Equal(http.StatusNotFound))
 	})
 })


### PR DESCRIPTION
- I skipped the wrong set of tests in https://github.com/devfile/registry-support/pull/121 🤦, this PR skips the right set of tests:
   ```
   •••••
   Ran 26 of 37 Specs in 11.266 seconds
   SUCCESS! -- 26 Passed | 0 Failed | 0 Pending | 11 Skipped
   PASS
    ```
    
- Adds a new PR check that runs the tests against staging, to ensure they pass as well (as these tests are used in the acceptance tests for promotions)