### PR TITLE
SubDir non-existent destination bug fix

### DIFF
--- a/index/generator/library/util.go
+++ b/index/generator/library/util.go
@@ -111,6 +111,11 @@ func DownloadStackFromGit(git *schema.Git, path string, verbose bool) ([]byte, e
 		return []byte{}, err
 	}
 
+	// Throw error if path was not created
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return []byte{}, err
+	}
+
 	// Zip directory containing downloaded git repo
 	if err := ZipDir(path, zipPath); err != nil {
 		return []byte{}, err

--- a/index/generator/library/util.go
+++ b/index/generator/library/util.go
@@ -213,6 +213,19 @@ func gitSubDir(srcPath, destinationPath, subDir string, fs filesystem.Filesystem
 			return err
 		}
 
+		// Create destinationPath if does not exist
+		if _, err = fs.Stat(destinationPath); os.IsNotExist(err) {
+			var srcinfo os.FileInfo
+
+			if srcinfo, err = fs.Stat(srcPath); err != nil {
+				return err
+			}
+
+			if err = fs.MkdirAll(destinationPath, srcinfo.Mode()); err != nil {
+				return err
+			}
+		}
+
 		// Loop over files.
 		for outputIndex := range outputDirFiles {
 			outputFileHere := outputDirFiles[outputIndex]

--- a/index/generator/library/util_test.go
+++ b/index/generator/library/util_test.go
@@ -57,7 +57,7 @@ func TestCloneRemoteStack(t *testing.T) {
 			"specifying commit in 'revision' is not yet supported",
 		},
 		{
-			"Case 4: Cloning a non-existant repo",
+			"Case 4: Cloning a non-existent repo",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/nonexist.git",
 				RemoteName: "origin",
@@ -213,7 +213,7 @@ func TestDownloadStackFromGit(t *testing.T) {
 			"specifying commit in 'revision' is not yet supported",
 		},
 		{
-			"Case 4: Cloning a non-existant repo",
+			"Case 4: Cloning a non-existent repo",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/nonexist.git",
 				RemoteName: "origin",

--- a/index/generator/library/util_test.go
+++ b/index/generator/library/util_test.go
@@ -24,7 +24,7 @@ func TestCloneRemoteStack(t *testing.T) {
 		wantErrStr string
 	}{
 		{
-			"Case 1: Maven Java (Without subDir)",
+			"Case 1: Maven Java",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
@@ -34,13 +34,14 @@ func TestCloneRemoteStack(t *testing.T) {
 			"",
 		},
 		{
-			"Case 2: Maven Java (With subDir)",
+			"Case 2: Wildfly Java - microprofile-config subdirectory",
 			&schema.Git{
-				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
-				RemoteName: "origin",
-				SubDir:     "src/main",
+				Url:        "https://github.com/wildfly/quickstart.git",
+				RemoteName: "wildfly-quickstart",
+				Revision:   "22.0.1.Final",
+				SubDir:     "microprofile-config",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
+			filepath.Join(os.TempDir(), "quickstart"),
 			false,
 			"",
 		},
@@ -179,7 +180,7 @@ func TestDownloadStackFromGit(t *testing.T) {
 		wantErrStr string
 	}{
 		{
-			"Case 1: Maven Java (Without subDir)",
+			"Case 1: Maven Java",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
@@ -189,13 +190,14 @@ func TestDownloadStackFromGit(t *testing.T) {
 			"",
 		},
 		{
-			"Case 2: Maven Java (With subDir)",
+			"Wildfly Java - microprofile-config subdirectory",
 			&schema.Git{
-				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
-				RemoteName: "origin",
-				SubDir:     "src/main",
+				Url:        "https://github.com/wildfly/quickstart.git",
+				RemoteName: "wildfly-quickstart",
+				Revision:   "22.0.1.Final",
+				SubDir:     "microprofile-config",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex-main"),
+			filepath.Join(os.TempDir(), "quickstart"),
 			false,
 			"",
 		},

--- a/index/generator/library/util_test.go
+++ b/index/generator/library/util_test.go
@@ -34,7 +34,18 @@ func TestCloneRemoteStack(t *testing.T) {
 			"",
 		},
 		{
-			"Case 2: Wildfly Java - microprofile-config subdirectory",
+			"Case 2: Maven Java (With subDir)",
+			&schema.Git{
+				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
+				RemoteName: "origin",
+				SubDir:     "src/main",
+			},
+			filepath.Join(os.TempDir(), "springboot-ex"),
+			false,
+			"",
+		},
+		{
+			"Case 3: Wildfly Java - microprofile-config subdirectory",
 			&schema.Git{
 				Url:        "https://github.com/wildfly/quickstart.git",
 				RemoteName: "wildfly-quickstart",
@@ -46,7 +57,7 @@ func TestCloneRemoteStack(t *testing.T) {
 			"",
 		},
 		{
-			"Case 3: Maven Java - Cloning with Hash Revision",
+			"Case 4: Maven Java - Cloning with Hash Revision",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
@@ -57,7 +68,7 @@ func TestCloneRemoteStack(t *testing.T) {
 			"specifying commit in 'revision' is not yet supported",
 		},
 		{
-			"Case 4: Cloning a non-existent repo",
+			"Case 5: Cloning a non-existent repo",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/nonexist.git",
 				RemoteName: "origin",
@@ -67,7 +78,7 @@ func TestCloneRemoteStack(t *testing.T) {
 			"",
 		},
 		{
-			"Case 5: Maven Java - Cloning with Invalid Revision",
+			"Case 6: Maven Java - Cloning with Invalid Revision",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
@@ -111,7 +122,7 @@ func TestDownloadStackFromZipUrl(t *testing.T) {
 		wantErrStr string
 	}{
 		{
-			"Case 1: Java Quarkus (Without subDir)",
+			"Case 1: Java Quarkus",
 			map[string]string{
 				"Name":   "quarkus",
 				"ZipUrl": "https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile",
@@ -190,7 +201,18 @@ func TestDownloadStackFromGit(t *testing.T) {
 			"",
 		},
 		{
-			"Wildfly Java - microprofile-config subdirectory",
+			"Case 2: Maven Java (With subDir)",
+			&schema.Git{
+				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
+				RemoteName: "origin",
+				SubDir:     "src/main",
+			},
+			filepath.Join(os.TempDir(), "springboot-ex"),
+			false,
+			"",
+		},
+		{
+			"Case 3: Wildfly Java - microprofile-config subdirectory",
 			&schema.Git{
 				Url:        "https://github.com/wildfly/quickstart.git",
 				RemoteName: "wildfly-quickstart",
@@ -202,7 +224,7 @@ func TestDownloadStackFromGit(t *testing.T) {
 			"",
 		},
 		{
-			"Case 3: Maven Java - Cloning with Hash Revision",
+			"Case 4: Maven Java - Cloning with Hash Revision",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
@@ -213,7 +235,7 @@ func TestDownloadStackFromGit(t *testing.T) {
 			"specifying commit in 'revision' is not yet supported",
 		},
 		{
-			"Case 4: Cloning a non-existent repo",
+			"Case 5: Cloning a non-existent repo",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/nonexist.git",
 				RemoteName: "origin",
@@ -223,7 +245,7 @@ func TestDownloadStackFromGit(t *testing.T) {
 			"",
 		},
 		{
-			"Case 5: Maven Java - Cloning with Invalid Revision",
+			"Case 6: Maven Java - Cloning with Invalid Revision",
 			&schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",

--- a/index/generator/library/util_test.go
+++ b/index/generator/library/util_test.go
@@ -24,69 +24,69 @@ func TestCloneRemoteStack(t *testing.T) {
 		wantErrStr string
 	}{
 		{
-			"Case 1: Maven Java",
-			&schema.Git{
+			name: "Case 1: Maven Java",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
-			false,
-			"",
+			path:       filepath.Join(os.TempDir(), "springboot-ex"),
+			wantErr:    false,
+			wantErrStr: "",
 		},
 		{
-			"Case 2: Maven Java (With subDir)",
-			&schema.Git{
+			name: "Case 2: Maven Java (With subDir)",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
 				SubDir:     "src/main",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
-			false,
-			"",
+			path:       filepath.Join(os.TempDir(), "springboot-ex"),
+			wantErr:    false,
+			wantErrStr: "",
 		},
 		{
-			"Case 3: Wildfly Java - microprofile-config subdirectory",
-			&schema.Git{
+			name: "Case 3: Wildfly Java - microprofile-config subdirectory",
+			git: &schema.Git{
 				Url:        "https://github.com/wildfly/quickstart.git",
 				RemoteName: "wildfly-quickstart",
 				Revision:   "22.0.1.Final",
 				SubDir:     "microprofile-config",
 			},
-			filepath.Join(os.TempDir(), "quickstart"),
-			false,
-			"",
+			path:       filepath.Join(os.TempDir(), "quickstart"),
+			wantErr:    false,
+			wantErrStr: "",
 		},
 		{
-			"Case 4: Maven Java - Cloning with Hash Revision",
-			&schema.Git{
+			name: "Case 4: Maven Java - Cloning with Hash Revision",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
 				Revision:   "694e96286ffdc3a9990d0041637d32cecba38181",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
-			true,
-			"specifying commit in 'revision' is not yet supported",
+			path:       filepath.Join(os.TempDir(), "springboot-ex"),
+			wantErr:    true,
+			wantErrStr: "specifying commit in 'revision' is not yet supported",
 		},
 		{
-			"Case 5: Cloning a non-existent repo",
-			&schema.Git{
+			name: "Case 5: Cloning a non-existent repo",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/nonexist.git",
 				RemoteName: "origin",
 			},
-			filepath.Join(os.TempDir(), "nonexist"),
-			true,
-			"",
+			path:       filepath.Join(os.TempDir(), "nonexist"),
+			wantErr:    true,
+			wantErrStr: "",
 		},
 		{
-			"Case 6: Maven Java - Cloning with Invalid Revision",
-			&schema.Git{
+			name: "Case 6: Maven Java - Cloning with Invalid Revision",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
 				Revision:   "invalid",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
-			true,
-			"couldn't find remote ref \"refs/tags/invalid\"",
+			path:       filepath.Join(os.TempDir(), "springboot-ex"),
+			wantErr:    true,
+			wantErrStr: "couldn't find remote ref \"refs/tags/invalid\"",
 		},
 	}
 
@@ -122,34 +122,34 @@ func TestDownloadStackFromZipUrl(t *testing.T) {
 		wantErrStr string
 	}{
 		{
-			"Case 1: Java Quarkus",
-			map[string]string{
+			name: "Case 1: Java Quarkus",
+			params: map[string]string{
 				"Name":   "quarkus",
 				"ZipUrl": "https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile",
 				"SubDir": "",
 			},
-			false,
-			"",
+			wantErr:    false,
+			wantErrStr: "",
 		},
 		{
-			"Case 2: Java Quarkus (With subDir)",
-			map[string]string{
+			name: "Case 2: Java Quarkus (With subDir)",
+			params: map[string]string{
 				"Name":   "quarkus",
 				"ZipUrl": "https://code.quarkus.io/d?e=io.quarkus%3Aquarkus-resteasy&e=io.quarkus%3Aquarkus-micrometer&e=io.quarkus%3Aquarkus-smallrye-health&e=io.quarkus%3Aquarkus-openshift&cn=devfile",
 				"SubDir": "src",
 			},
-			false,
-			"",
+			wantErr:    false,
+			wantErrStr: "",
 		},
 		{
-			"Case 3: Download error",
-			map[string]string{
+			name: "Case 3: Download error",
+			params: map[string]string{
 				"Name":   "quarkus",
 				"ZipUrl": "https://code.quarkus.io/d?e=io.quarkus",
 				"SubDir": "",
 			},
-			true,
-			"failed to retrieve https://code.quarkus.io/d?e=io.quarkus, 400: Bad Request",
+			wantErr:    true,
+			wantErrStr: "failed to retrieve https://code.quarkus.io/d?e=io.quarkus, 400: Bad Request",
 		},
 	}
 
@@ -191,69 +191,69 @@ func TestDownloadStackFromGit(t *testing.T) {
 		wantErrStr string
 	}{
 		{
-			"Case 1: Maven Java",
-			&schema.Git{
+			name: "Case 1: Maven Java",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
-			false,
-			"",
+			path:       filepath.Join(os.TempDir(), "springboot-ex"),
+			wantErr:    false,
+			wantErrStr: "",
 		},
 		{
-			"Case 2: Maven Java (With subDir)",
-			&schema.Git{
+			name: "Case 2: Maven Java (With subDir)",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
 				SubDir:     "src/main",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
-			false,
-			"",
+			path:       filepath.Join(os.TempDir(), "springboot-ex"),
+			wantErr:    false,
+			wantErrStr: "",
 		},
 		{
-			"Case 3: Wildfly Java - microprofile-config subdirectory",
-			&schema.Git{
+			name: "Case 3: Wildfly Java - microprofile-config subdirectory",
+			git: &schema.Git{
 				Url:        "https://github.com/wildfly/quickstart.git",
 				RemoteName: "wildfly-quickstart",
 				Revision:   "22.0.1.Final",
 				SubDir:     "microprofile-config",
 			},
-			filepath.Join(os.TempDir(), "quickstart"),
-			false,
-			"",
+			path:       filepath.Join(os.TempDir(), "quickstart"),
+			wantErr:    false,
+			wantErrStr: "",
 		},
 		{
-			"Case 4: Maven Java - Cloning with Hash Revision",
-			&schema.Git{
+			name: "Case 4: Maven Java - Cloning with Hash Revision",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
 				Revision:   "694e96286ffdc3a9990d0041637d32cecba38181",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
-			true,
-			"specifying commit in 'revision' is not yet supported",
+			path:       filepath.Join(os.TempDir(), "springboot-ex"),
+			wantErr:    true,
+			wantErrStr: "specifying commit in 'revision' is not yet supported",
 		},
 		{
-			"Case 5: Cloning a non-existent repo",
-			&schema.Git{
+			name: "Case 5: Cloning a non-existent repo",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/nonexist.git",
 				RemoteName: "origin",
 			},
-			filepath.Join(os.TempDir(), "nonexist"),
-			true,
-			"",
+			path:       filepath.Join(os.TempDir(), "nonexist"),
+			wantErr:    true,
+			wantErrStr: "",
 		},
 		{
-			"Case 6: Maven Java - Cloning with Invalid Revision",
-			&schema.Git{
+			name: "Case 6: Maven Java - Cloning with Invalid Revision",
+			git: &schema.Git{
 				Url:        "https://github.com/odo-devfiles/springboot-ex.git",
 				RemoteName: "origin",
 				Revision:   "invalid",
 			},
-			filepath.Join(os.TempDir(), "springboot-ex"),
-			true,
-			"couldn't find remote ref \"refs/tags/invalid\"",
+			path:       filepath.Join(os.TempDir(), "springboot-ex"),
+			wantErr:    true,
+			wantErrStr: "couldn't find remote ref \"refs/tags/invalid\"",
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**
registry-support/index/generator

**What does does this PR do / why we need it**:

Changes in this PR provides the extra process of creating the base directory, if non-existent, for the operation performed by `copyFileWithFs` on [index/generator/libraryutil.go#L223](https://github.com/devfile/registry-support/blob/a7d0871221ba0a27696739870d855116ecc98e0c/index/generator/library/util.go#L223). Without this, certain starter project downloads such as [Java Wildfly](https://registry.devfile.io/viewer/devfiles/Community+java-wildfly) fail with an error seen in devfile/api#867.

Additional changes include an additional test case which includes the Java Wildfly starter project to perform further testing on starter project downloads using the `subDir` property.

**Which issue(s) this PR fixes**:

Fixes #?
partially fix devfile/api#867

**PR acceptance criteria**:

- [ ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
```sh
cd index/generator
go test -v ./...
```