### PR TITLE
Update index/generator version for bug fix in index/server dependencies

### DIFF
--- a/index/server/go.mod
+++ b/index/server/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/deislabs/oras v0.8.1
 	github.com/devfile/api/v2 v2.0.0-20220117162434-6e6e6a8bc14c
 	github.com/devfile/library v1.2.1-0.20220308191614-f0f7e11b17de
-	github.com/devfile/registry-support/index/generator v0.0.0-20220316161530-f06d84c42b54
+	github.com/devfile/registry-support/index/generator v0.0.0-20220624203950-e7282a4695b6
 	github.com/gin-gonic/gin v1.7.7
 	github.com/hashicorp/go-version v1.4.0
 	github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348

--- a/index/server/go.sum
+++ b/index/server/go.sum
@@ -142,6 +142,8 @@ github.com/devfile/library v1.2.1-0.20220308191614-f0f7e11b17de h1:jImHtiAxjyul1
 github.com/devfile/library v1.2.1-0.20220308191614-f0f7e11b17de/go.mod h1:GSPfJaBg0+bBjBHbwBE5aerJLH6tWGQu2q2rHYd9czM=
 github.com/devfile/registry-support/index/generator v0.0.0-20220316161530-f06d84c42b54 h1:k7F4Hc4svkA+qHerBTZzcU1iVrQAJHOh8KurPnL4uYk=
 github.com/devfile/registry-support/index/generator v0.0.0-20220316161530-f06d84c42b54/go.mod h1:1fyDJL+fPHtcrYA6yjSVWeLmXmjCNth0d5Rq1rvtryc=
+github.com/devfile/registry-support/index/generator v0.0.0-20220624203950-e7282a4695b6 h1:bTbZxKSjF9xfiUuOKpoyX7P/ZcnIRy993+JBvkQ91hw=
+github.com/devfile/registry-support/index/generator v0.0.0-20220624203950-e7282a4695b6/go.mod h1:1fyDJL+fPHtcrYA6yjSVWeLmXmjCNth0d5Rq1rvtryc=
 github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=

--- a/index/server/vendor/github.com/devfile/registry-support/index/generator/library/util.go
+++ b/index/server/vendor/github.com/devfile/registry-support/index/generator/library/util.go
@@ -111,6 +111,11 @@ func DownloadStackFromGit(git *schema.Git, path string, verbose bool) ([]byte, e
 		return []byte{}, err
 	}
 
+	// Throw error if path was not created
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return []byte{}, err
+	}
+
 	// Zip directory containing downloaded git repo
 	if err := ZipDir(path, zipPath); err != nil {
 		return []byte{}, err
@@ -206,6 +211,19 @@ func gitSubDir(srcPath, destinationPath, subDir string, fs filesystem.Filesystem
 		outputDirFiles, err := outputDirRead.Readdir(0)
 		if err != nil {
 			return err
+		}
+
+		// Create destinationPath if does not exist
+		if _, err = fs.Stat(destinationPath); os.IsNotExist(err) {
+			var srcinfo os.FileInfo
+
+			if srcinfo, err = fs.Stat(srcPath); err != nil {
+				return err
+			}
+
+			if err = fs.MkdirAll(destinationPath, srcinfo.Mode()); err != nil {
+				return err
+			}
 		}
 
 		// Loop over files.

--- a/index/server/vendor/modules.txt
+++ b/index/server/vendor/modules.txt
@@ -100,7 +100,7 @@ github.com/devfile/library/pkg/devfile/parser/data/v2/common
 github.com/devfile/library/pkg/devfile/validate
 github.com/devfile/library/pkg/testingutil/filesystem
 github.com/devfile/library/pkg/util
-# github.com/devfile/registry-support/index/generator v0.0.0-20220316161530-f06d84c42b54
+# github.com/devfile/registry-support/index/generator v0.0.0-20220624203950-e7282a4695b6
 ## explicit; go 1.14
 github.com/devfile/registry-support/index/generator/library
 github.com/devfile/registry-support/index/generator/schema


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**
registry-support/index/server

**What does does this PR do / why we need it**:

Applies an update to the index/server's dependency index/generator in order to fix a bug found in devfile/api#867 and fixed in PR #124. See PR #124 for more details on fix changes.

**Which issue(s) this PR fixes**:

Fixes #?
fixes devfile/api#867

**PR acceptance criteria**:

- [ ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
