### PR TITLE
Minor REST api doc fix

### DIFF
--- a/index/server/registry-REST-API.adoc
+++ b/index/server/registry-REST-API.adoc
@@ -25,7 +25,7 @@ xref:Gets registry v2 index of all devfile types[all types]
 
 xref:Gets registry stack devfile with version[]
 
-|/devfiles/:stack/starterProjects
+|/devfiles/:stack/starter-projects
 |xref:Download Starter Project from requested Devfile[]
 
 xref:Download Starter Project from requested Devfile with Version[]


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

registry

**What does does this PR do / why we need it**:

This PR corrects a missed change which should of been done in PR #119. `/devfiles/:stack/starterProjects` route definition under the [Content Guide](https://github.com/devfile/registry-support/blob/3861d54237e82bfe3debe46e36d24845694f564d/index/server/registry-REST-API.adoc#content-guide) table is now changed to the current `/devfiles/:stack/starter-projects` route.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
