### PR TITLE
Minor changes to the download cmd in handling the context path and bug fixes

### DIFF
--- a/registry-library/cmd/root.go
+++ b/registry-library/cmd/root.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -164,7 +163,7 @@ func init() {
 				SkipTLSVerify: skipTLSVerify,
 			}
 
-			err = library.DownloadStarterProjectAsDir(filepath.Join(destDir, starterProject), registry, stack, starterProject, options)
+			err = library.DownloadStarterProjectAsDir(destDir, registry, stack, starterProject, options)
 			if err != nil {
 				fmt.Printf("failed to download starter project %s: %v\n", starterProject, err)
 			}

--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -326,7 +326,7 @@ func DownloadStarterProjectAsDir(path string, registryURL string, stack string, 
 		filePath := filepath.Join(path, file.Name)
 
 		// validate extracted filepath
-		if !strings.HasPrefix(filePath, filepath.Clean(path)+string(os.PathSeparator)) {
+		if filePath != file.Name && !strings.HasPrefix(filePath, filepath.Clean(path)+string(os.PathSeparator)) {
 			return fmt.Errorf("invalid file path %s", filePath)
 		}
 

--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -423,7 +423,7 @@ func DownloadStarterProjectAsBytes(registryURL string, stack string, starterProj
 		return nil, err
 	}
 
-	url := fmt.Sprintf("%s/%s", urlObj.String(), path.Join("devfiles", stackName, "starter-projects", starterProject))
+	url := fmt.Sprintf("%s://%s", urlObj.Scheme, path.Join(urlObj.Host, "devfiles", stackName, "starter-projects", starterProject))
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err

--- a/tests/integration/pkg/tests/devfilelibrary_tests.go
+++ b/tests/integration/pkg/tests/devfilelibrary_tests.go
@@ -129,19 +129,17 @@ var _ = ginkgo.Describe("[Verify registry library works with registry]", func() 
 	})
 
 	ginkgo.It("should properly download stack starter project", func() {
-		tempDir := os.TempDir()
+		tempDir := path.Join(os.TempDir(), javaMavenStarter)
 		util.CmdShouldPass("registry-library", "download", publicDevfileRegistry, javaMavenStack, javaMavenStarter, "--context", tempDir)
-		starterPath := path.Join(tempDir, javaMavenStarter)
-		info, err := os.Stat(starterPath)
+		info, err := os.Stat(tempDir)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(info.IsDir()).To(gomega.Equal(true))
 	})
 
 	ginkgo.It("should properly download V2 stack starter project", func() {
-		tempDir := os.TempDir()
+		tempDir := path.Join(os.TempDir(), goStarter)
 		util.CmdShouldPass("registry-library", "download", publicDevfileRegistry, goStack, goStarter, "--context", tempDir, "--new-index-schema")
-		starterPath := path.Join(tempDir, goStarter)
-		info, err := os.Stat(starterPath)
+		info, err := os.Stat(tempDir)
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(info.IsDir()).To(gomega.Equal(true))
 	})

--- a/tests/integration/pkg/tests/devfilelibrary_tests.go
+++ b/tests/integration/pkg/tests/devfilelibrary_tests.go
@@ -143,4 +143,28 @@ var _ = ginkgo.Describe("[Verify registry library works with registry]", func() 
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(info.IsDir()).To(gomega.Equal(true))
 	})
+
+	ginkgo.It("should properly download stack starter project with hostname url ending with '/'", func() {
+		tempDir := path.Join(os.TempDir(), javaMavenStarter)
+		util.CmdShouldPass("registry-library", "download", publicDevfileRegistry+"/", javaMavenStack, javaMavenStarter, "--context", tempDir)
+		info, err := os.Stat(tempDir)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(info.IsDir()).To(gomega.Equal(true))
+	})
+
+	ginkgo.It("should properly download stack starter project with context set to relative path of WD (default)", func() {
+		originalDir, err := os.Getwd()
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		err = os.Chdir(os.TempDir())
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+		util.CmdShouldPass("registry-library", "download", publicDevfileRegistry+"/", javaMavenStack, javaMavenStarter)
+		info, err := os.Stat(".")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(info.IsDir()).To(gomega.Equal(true))
+
+		err = os.Chdir(originalDir)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	})
 })


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**
registry library

**What does does this PR do / why we need it**:

Recently added in PR #126, the `registry download` command downloads and extracts a starter project to a given context path (default `.`). At this time, it will create a sub-directory under the context path to extract the starter project contents to, however, it would be more useful and consistent with `registry pull` to extract the contents directly into the context path itself which is what this PR intents to provide. 

After this change, one can still create a sub-directory by specifying `--context=./<subdirectory_name>`. 

Other Changes:

- Bug fix to `DownloadStarterProjectAsDir` extract ZipSlip check, if the entire resultant file path is the just the file name (no directory prefix) do not perform check.
    - Without this fix the function will error in all cases of using the relative path to the present working directory `.`.
- Bug fix to `DownloadStarterProjectAsBytes` not downloading correctly if base registry url ends with `/`

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#892
fixes devfile/api#895

**PR acceptance criteria**:

- [ ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
