### PR TITLE
Unset error accessor removed from version not found response

### DIFF
--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -533,7 +533,6 @@ func fetchDevfile(c *gin.Context, name string, version string) ([]byte, indexSch
 					}
 				} else {
 					c.JSON(http.StatusNotFound, gin.H{
-						"error":  err.Error(),
 						"status": fmt.Sprintf("version: %s not found in stack %s", version, name),
 					})
 					return []byte{}, indexSchema.Schema{}


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**
registry index/server

**What does does this PR do / why we need it**:

Removes error reporting of a non-existent error from [/index/server/pkg/server/endpoint.go#L536](https://github.com/devfile/registry-support/blob/f017dd16617c1045c568c477f6f90ea2f1d91547/index/server/pkg/server/endpoint.go#L536) which is causing an unexpected panic due to the error being `nil`.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#901

**PR acceptance criteria**:

- [ ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
