### PR TITLE
Track telemetry download events for GET requests only

### DIFF
--- a/index/server/pkg/server/index.go
+++ b/index/server/pkg/server/index.go
@@ -171,8 +171,8 @@ func ociServerProxy(c *gin.Context) {
 	proxy := httputil.NewSingleHostReverseProxy(remote)
 
 	// Set up the request to the proxy
-	// Track event for telemetry
-	if enableTelemetry {
+	// Track event for telemetry for GET requests only
+	if enableTelemetry && c.Request.Method == http.MethodGet {
 		proxyPath := c.Param("proxyPath")
 		if proxyPath != "" {
 			var name string


### PR DESCRIPTION
Signed-off-by: Kim Tsao <ktsao@redhat.com>

**Please specify the area for this PR**
/area registry

**What does does this PR do / why we need it**:
The proxy endpoint handles GET and HEAD requests which is contributing to duplicate download calls (in some cases, like the go devfile).  This should reduce the number of actions we're receiving in Segment

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/888

**PR acceptance criteria**:

- [x ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:

-  built and deployed devfile-index image with fix and observed one download event passing through Segment for Go devfile (used `odo init` to trigger download)
-  deployed latest prod devfile-index (without fix) and observed two download events for Go devfile, one download event for python and java-maven

