### PR TITLE
proxy support for registry

### DIFF
--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -17,7 +17,6 @@ package library
 
 import (
 	"archive/zip"
-	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -82,7 +81,7 @@ type TelemetryData struct {
 
 type RegistryOptions struct {
 	// SkipTLSVerify is false by default which is the recommended setting for a devfile registry deployed in production.  SkipTLSVerify should only be set to true
-	// if you are testing a devfile registry that is set up with self-signed certificates in a pre-production environment.
+	// if you are testing a devfile registry or proxy server that is set up with self-signed certificates in a pre-production environment.
 	SkipTLSVerify bool
 	// Telemetry allows clients to send telemetry data to the community Devfile Registry
 	Telemetry TelemetryData
@@ -172,13 +171,8 @@ func GetRegistryIndex(registryURL string, options RegistryOptions, devfileTypes 
 
 	setHeaders(&req.Header, options)
 
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			ResponseHeaderTimeout: responseHeaderTimeout,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: options.SkipTLSVerify},
-		},
-		Timeout: httpRequestTimeout,
-	}
+	httpClient := getHTTPClient(options)
+
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -261,11 +255,8 @@ func PullStackByMediaTypesFromRegistry(registry string, stack string, allowedMed
 	if urlObj.Scheme == "https" {
 		plainHTTP = false
 	}
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: options.SkipTLSVerify},
-		},
-	}
+	httpClient := getHTTPClient(options)
+
 	headers := make(http.Header)
 	setHeaders(&headers, options)
 
@@ -431,13 +422,7 @@ func DownloadStarterProjectAsBytes(registryURL string, stack string, starterProj
 
 	setHeaders(&req.Header, options)
 
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			ResponseHeaderTimeout: responseHeaderTimeout,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: options.SkipTLSVerify},
-		},
-		Timeout: httpRequestTimeout,
-	}
+	httpClient := getHTTPClient(options)
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/registry-library/library/util.go
+++ b/registry-library/library/util.go
@@ -18,6 +18,7 @@ package library
 import (
 	"archive/tar"
 	"compress/gzip"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"log"
@@ -141,5 +142,17 @@ func setHeaders(headers *http.Header, options RegistryOptions) {
 	}
 	if t.Locale != "" {
 		headers.Add("Locale", t.Locale)
+	}
+}
+
+//getHTTPClient returns a new http client object
+func getHTTPClient(options RegistryOptions) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: responseHeaderTimeout,
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: options.SkipTLSVerify},
+		},
+		Timeout: httpRequestTimeout,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Kim Tsao <ktsao@redhat.com>

**Please specify the area for this PR**
/area registry

**What does does this PR do / why we need it**:
Introduces proxy support for the registry.  Clients such as OCP allow their users to set up a proxy server (typical of air-gapped environments) but this will cause the devfile registry to be unreachable.  The fix is to update our custom HTTP transport to recognize the proxy that's set in the environment.  

**Which issue(s) this PR fixes**:

Fixes #?

https://github.com/devfile/api/issues/897

**PR acceptance criteria**:

- [x ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:

- Console QE tested on a remote OCP cluster with an HTTP proxy and confirmed the devfile catalog was able to load.  I also inspected the console logs and confirmed the proxy was being picked up from the environment.  Note, this set up was for test purposes only.  Once the fix is final, only trusted,  HTTPS proxies will be supported in the console.  See https://docs.openshift.com/container-platform/4.11/security/certificate_types_descriptions/proxy-certificates.html
