### PR TITLE
custom timeout support for registry

### DIFF
--- a/registry-library/README.md
+++ b/registry-library/README.md
@@ -121,6 +121,13 @@ Supported devfile media types can be found in the latest version of [library.go]
         },
     }
     ```
+6.  Override the HTTP request and response timeout values
+   ```go
+   customTimeout := 20
+   options := registryLibrary.RegistryOptions{
+      HTTPTimeout: &customTimeout
+   }
+   ```
 
 #### Download the starter project
 

--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -50,8 +50,7 @@ const (
 
 	OwnersFile = "OWNERS"
 
-	httpRequestTimeout    = 30 * time.Second // httpRequestTimeout configures timeout of all HTTP requests
-	responseHeaderTimeout = 30 * time.Second // responseHeaderTimeout is the timeout to retrieve the server's response headers
+	httpRequestResponseTimeout = 30 * time.Second // httpRequestTimeout configures timeout of all HTTP requests
 )
 
 var (
@@ -90,6 +89,8 @@ type RegistryOptions struct {
 	// NewIndexSchema is false by default, which calls GET /index and returns index of default version of each stack using the old index schema struct.
 	// If specified to true, calls GET /v2index and returns the new Index schema with multi-version support
 	NewIndexSchema bool
+	// HTTPTimeout overrides the request and response timeout values for the custom HTTP clients set by the registry library.  If unset or a negative value is specified, the default timeout of 30s will be used.
+	HTTPTimeout *int
 }
 
 type RegistryFilter struct {

--- a/registry-library/library/library_test.go
+++ b/registry-library/library/library_test.go
@@ -257,6 +257,9 @@ func setUpTestServer(t *testing.T) (func(), error) {
 }
 
 func TestGetRegistryIndex(t *testing.T) {
+	invalidHTTPTimeout := -1
+	validHTTPTimeout := 10
+
 	close, err := setUpTestServer(t)
 	if err != nil {
 		t.Error(err)
@@ -289,6 +292,30 @@ func TestGetRegistryIndex(t *testing.T) {
 			name: "Get Arch Filtered Index",
 			url:  "http://" + serverIP,
 			options: RegistryOptions{
+				Filter: RegistryFilter{
+					Architectures: []string{"amd64", "arm64"},
+				},
+			},
+			devfileTypes: []indexSchema.DevfileType{indexSchema.SampleDevfileType},
+			wantSchemas:  archFilteredIndex,
+		},
+		{
+			name: "Get Registry Index with invalid httpTimeout value",
+			url:  "http://" + serverIP,
+			options: RegistryOptions{
+				HTTPTimeout: &invalidHTTPTimeout,
+				Filter: RegistryFilter{
+					Architectures: []string{"amd64", "arm64"},
+				},
+			},
+			devfileTypes: []indexSchema.DevfileType{indexSchema.SampleDevfileType},
+			wantSchemas:  archFilteredIndex,
+		},
+		{
+			name: "Get Registry Index with valid httpTimeout value",
+			url:  "http://" + serverIP,
+			options: RegistryOptions{
+				HTTPTimeout: &validHTTPTimeout,
 				Filter: RegistryFilter{
 					Architectures: []string{"amd64", "arm64"},
 				},

--- a/registry-library/library/util.go
+++ b/registry-library/library/util.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"time"
 )
 
 // SplitVersionFromStack takes a stack/version tag and splits the stack name from the version
@@ -147,12 +148,21 @@ func setHeaders(headers *http.Header, options RegistryOptions) {
 
 //getHTTPClient returns a new http client object
 func getHTTPClient(options RegistryOptions) *http.Client {
+
+	overriddenTimeout := httpRequestResponseTimeout
+	timeout := options.HTTPTimeout
+	//if value is invalid or unspecified, the default will be used
+	if timeout != nil && *timeout > 0 {
+		//convert timeout to seconds
+		overriddenTimeout = time.Duration(*timeout) * time.Second
+	}
+
 	return &http.Client{
 		Transport: &http.Transport{
 			Proxy:                 http.ProxyFromEnvironment,
-			ResponseHeaderTimeout: responseHeaderTimeout,
+			ResponseHeaderTimeout: overriddenTimeout,
 			TLSClientConfig:       &tls.Config{InsecureSkipVerify: options.SkipTLSVerify},
 		},
-		Timeout: httpRequestTimeout,
+		Timeout: overriddenTimeout,
 	}
 }


### PR DESCRIPTION
Signed-off-by: Kim Tsao <ktsao@redhat.com>

**Please specify the area for this PR**

**What does does this PR do / why we need it**:

We need to update the registry options to allow clients to override the HTTP request/response timeouts. 

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/926

**PR acceptance criteria**:

- [ ] Test (WIP) 

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:

Need to rely on console team to test this out
