### PR TITLE
Allow registry-viewer folder to be passed in during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ If you want to run the build scripts with Podman, set the environment variable
 
 To build all of the components together (recommended) for dev/test, run `./build_registry.sh` to build a Devfile Registry index image that is populated with the mock devfile registry data under `tests/registry/`.
 
+Alternatively, if you wish to build with custom version of the devfile registry viewer, you can pass a path to a folder containing the registry viewer as an optional argument:
+
+`$ ./build_registry.sh <path-to-registry-viewer>`
+
 Once the container has been pushed, you can push it to a container registry of your choosing with the following commands:
 
 ```

--- a/build_registry.sh
+++ b/build_registry.sh
@@ -4,12 +4,14 @@
 # This can be useful if developing components within this repository (such as the index server or build tools)
 # and want to test all of the components together
 shopt -s expand_aliases
-set -eux
+set -ex
+
+registryViewerPath=$1
 #set the docker alias if necessary
 . ./setenv.sh
 
 # Build the index server base image
-. ./index/server/build.sh
+. ./index/server/build.sh $registryViewerPath
 
 # Build the test devfile registry image
 docker build -t devfile-index:latest -f .ci/Dockerfile .

--- a/index/server/build.sh
+++ b/index/server/build.sh
@@ -2,15 +2,20 @@
 
 # Build the index container for the registry
 buildfolder="$(realpath $(dirname ${BASH_SOURCE[0]}))"
+registryViewerPath=$1
 
-# Clone the registry-support repo
-if [ -d $buildfolder/registry-viewer ]; then
-	rm -rf $buildfolder/registry-viewer
+if [ ! -z $registryViewer ]; then
+    # Clone the registry-support repo
+    registryViewerPath=$buildfolder/registry-viewer
+    if [ -d $buildfolder/registry-viewer ]; then
+        rm -rf $registryViewerPath
+    fi
+
+    git clone https://github.com/devfile/registry-viewer.git $registryViewerPath
 fi
-git clone https://github.com/devfile/registry-viewer.git $buildfolder/registry-viewer
 
 # Build the registry viewer
-docker build -t registry-viewer --target builder --build-arg DEVFILE_VIEWER_ROOT=/viewer --build-arg DEVFILE_COMMUNITY_HOST=false $buildfolder/registry-viewer
+docker build -t registry-viewer --target builder --build-arg DEVFILE_VIEWER_ROOT=/viewer --build-arg DEVFILE_COMMUNITY_HOST=false $registryViewerPath
 
 # Build the index server
 docker build -t devfile-index-base:latest $buildfolder


### PR DESCRIPTION
- Updates the registry build script (build_registry.sh) to allow a registry viewer folder to be optionally passed in, making it easier to build and test with custom registry viewer instances.
- Updates the readme to reference this new functionality.