### PR TITLE
backport proxy support.  Includes fixes for both devfile/api#926 and …

### DIFF
--- a/registry-library/README.md
+++ b/registry-library/README.md
@@ -12,19 +12,18 @@ Devfile registry library is used for interacting with devfile registry, consumer
 
 ## How to use it
 1. Import devfile registry library
-```go
-import (
-    registryLibrary "github.com/devfile/registry-support/registry-library/library"
-)
-```
+   ```go
+   import (
+       registryLibrary "github.com/devfile/registry-support/registry-library/library"
+   )
+   ```
 2. Invoke devfile registry library
-
     a. Get the index of devfile registry for various devfile types
     ```go
     registryIndex, err := registryLibrary.GetRegistryIndex(registryURL, options, StackDevfileType)
-	if err != nil {
-		return err
-	}
+    if err != nil {
+        return err
+    }
     ```
     b. Get the indices of multiple devfile registries for various devfile types
     ```go
@@ -32,17 +31,17 @@ import (
     ```
     c. Download the stack devfile from devfile registry
     ```go
-	err := registryLibrary.PullStackByMediaTypesFromRegistry(registry, stack, registryLibrary.DevfileMediaTypeList, destDir, options)
-	if err != nil {
-		return err
-	}
+    err := registryLibrary.PullStackByMediaTypesFromRegistry(registry, stack, registryLibrary.DevfileMediaTypeList, destDir, options)
+    if err != nil {
+        return err
+    }
     ```
     d. Download the whole stack from devfile registry
     ```go
     err := registryLibrary.PullStackFromRegistry(registry, stack, destDir, options)
     if err != nil {
-		return err
-	}
+        return err
+    }
     ```
     e. Specify Options
     ```go
@@ -54,3 +53,11 @@ import (
         },
     }
     ```
+    f. Override the HTTP request and response timeout values
+    ```go
+    customTimeout := 20
+    options := registryLibrary.RegistryOptions{
+      HTTPTimeout: &customTimeout
+    }
+    ```
+   

--- a/registry-library/library/library_test.go
+++ b/registry-library/library/library_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestGetRegistryIndex(t *testing.T) {
 	const serverIP = "127.0.0.1:8080"
+	invalidHTTPTimeout := -1
+	validHTTPTimeout := 10
 	archFilteredIndex := []indexSchema.Schema{
 		{
 			Name:          "archindex1",
@@ -134,6 +136,30 @@ func TestGetRegistryIndex(t *testing.T) {
 			name:    "Not a URL",
 			url:     serverIP,
 			wantErr: true,
+		},
+		{
+			name: "Get Registry Index with invalid httpTimeout value",
+			url:  "http://" + serverIP,
+			options: RegistryOptions{
+				HTTPTimeout: &invalidHTTPTimeout,
+				Filter: RegistryFilter{
+					Architectures: []string{"amd64", "arm64"},
+				},
+			},
+			devfileTypes: []indexSchema.DevfileType{indexSchema.SampleDevfileType},
+			wantSchemas:  archFilteredIndex,
+		},
+		{
+			name: "Get Registry Index with valid httpTimeout value",
+			url:  "http://" + serverIP,
+			options: RegistryOptions{
+				HTTPTimeout: &validHTTPTimeout,
+				Filter: RegistryFilter{
+					Architectures: []string{"amd64", "arm64"},
+				},
+			},
+			devfileTypes: []indexSchema.DevfileType{indexSchema.SampleDevfileType},
+			wantSchemas:  archFilteredIndex,
 		},
 	}
 


### PR DESCRIPTION
…devfile/api#897

Signed-off-by: Kim Tsao <ktsao@redhat.com>

**Please specify the area for this PR**

**What does does this PR do / why we need it**:

Backports proxy fixes to a registry-library version that is compatible with console 4.10 (and possibly 4.9)

**Which issue(s) this PR fixes**:

Fixes #?
devfile/api#926 and devfile/api#897

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
We are relying on the console team to test
Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
