### PR TITLE
backport proxy changes to console 4.9

### DIFF
--- a/registry-library/README.md
+++ b/registry-library/README.md
@@ -12,19 +12,18 @@ Devfile registry library is used for interacting with devfile registry, consumer
 
 ## How to use it
 1. Import devfile registry library
-```go
-import (
-    registryLibrary "github.com/devfile/registry-support/registry-library/library"
-)
-```
+   ```go
+   import (
+       registryLibrary "github.com/devfile/registry-support/registry-library/library"
+   )
+   ```
 2. Invoke devfile registry library
-
     a. Get the index of devfile registry for various devfile types
     ```go
     registryIndex, err := registryLibrary.GetRegistryIndex(registryURL, options, StackDevfileType)
-	if err != nil {
-		return err
-	}
+    if err != nil {
+        return err
+    }
     ```
     b. Get the indices of multiple devfile registries for various devfile types
     ```go
@@ -32,17 +31,17 @@ import (
     ```
     c. Download the stack devfile from devfile registry
     ```go
-	err := registryLibrary.PullStackByMediaTypesFromRegistry(registry, stack, registryLibrary.DevfileMediaTypeList, destDir, options)
-	if err != nil {
-		return err
-	}
+    err := registryLibrary.PullStackByMediaTypesFromRegistry(registry, stack, registryLibrary.DevfileMediaTypeList, destDir, options)
+    if err != nil {
+        return err
+    }
     ```
     d. Download the whole stack from devfile registry
     ```go
     err := registryLibrary.PullStackFromRegistry(registry, stack, destDir, options)
     if err != nil {
-		return err
-	}
+        return err
+    }
     ```
     e. Specify Options
     ```go
@@ -54,3 +53,11 @@ import (
         },
     }
     ```
+    f. Override the HTTP request and response timeout values
+    ```go
+    customTimeout := 20
+    options := registryLibrary.RegistryOptions{
+      HTTPTimeout: &customTimeout
+    }
+    ```
+   

--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -1,13 +1,17 @@
-//
-// Copyright (c) 2020 Red Hat, Inc.
-// This program and the accompanying materials are made
-// available under the terms of the Eclipse Public License 2.0
-// which is available at https://www.eclipse.org/legal/epl-2.0/
-//
-// SPDX-License-Identifier: EPL-2.0
-//
-// Contributors:
-//   Red Hat, Inc. - initial API and implementation
+/*   Copyright 2020-2022 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package library
 
@@ -47,8 +51,7 @@ const (
 	DevfilePNGLogoMediaType = "image/png"
 	DevfileArchiveMediaType = "application/x-tar"
 
-	httpRequestTimeout    = 30 * time.Second // httpRequestTimeout configures timeout of all HTTP requests
-	responseHeaderTimeout = 30 * time.Second // responseHeaderTimeout is the timeout to retrieve the server's response headers
+	httpRequestResponseTimeout = 30 * time.Second // httpRequestTimeout configures timeout of all HTTP requests
 )
 
 var (
@@ -66,6 +69,7 @@ type RegistryOptions struct {
 	SkipTLSVerify bool
 	User          string
 	Filter        RegistryFilter
+	HTTPTimeout   *int
 }
 
 type RegistryFilter struct {
@@ -130,13 +134,9 @@ func GetRegistryIndex(registryURL string, options RegistryOptions, devfileTypes 
 	if options.User != "" {
 		req.Header.Add("User", options.User)
 	}
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			ResponseHeaderTimeout: responseHeaderTimeout,
-			TLSClientConfig:       &tls.Config{InsecureSkipVerify: options.SkipTLSVerify},
-		},
-		Timeout: httpRequestTimeout,
-	}
+
+	httpClient := getHTTPClient(options)
+
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ func GetRegistryIndex(registryURL string, options RegistryOptions, devfileTypes 
 	return registryIndex, nil
 }
 
-// GetMultipleRegistryIndices returns returns the list of stacks and/or samples of multiple registries
+// GetMultipleRegistryIndices returns the list of stacks and/or samples of multiple registries
 func GetMultipleRegistryIndices(registryURLs []string, options RegistryOptions, devfileTypes ...indexSchema.DevfileType) []Registry {
 	registryList := make([]Registry, len(registryURLs))
 	registryContentsChannel := make(chan []indexSchema.Schema)
@@ -232,11 +232,9 @@ func PullStackByMediaTypesFromRegistry(registry string, stack string, allowedMed
 	if urlObj.Scheme == "https" {
 		plainHTTP = false
 	}
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: options.SkipTLSVerify},
-		},
-	}
+
+	httpClient := getHTTPClient(options)
+
 	headers := make(http.Header)
 	if options.User != "" {
 		headers.Add("User", options.User)
@@ -320,4 +318,25 @@ func decompress(targetDir string, tarFile string) error {
 	}
 
 	return nil
+}
+
+//getHTTPClient returns a new http client object
+func getHTTPClient(options RegistryOptions) *http.Client {
+
+	overriddenTimeout := httpRequestResponseTimeout
+	timeout := options.HTTPTimeout
+	//if value is invalid or unspecified, the default will be used
+	if timeout != nil && *timeout > 0 {
+		//convert timeout to seconds
+		overriddenTimeout = time.Duration(*timeout) * time.Second
+	}
+
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy:                 http.ProxyFromEnvironment,
+			ResponseHeaderTimeout: overriddenTimeout,
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: options.SkipTLSVerify},
+		},
+		Timeout: overriddenTimeout,
+	}
 }

--- a/registry-library/library/library_test.go
+++ b/registry-library/library/library_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestGetRegistryIndex(t *testing.T) {
 	const serverIP = "127.0.0.1:8080"
+	invalidHTTPTimeout := -1
+	validHTTPTimeout := 10
 	archFilteredIndex := []indexSchema.Schema{
 		{
 			Name:          "archindex1",
@@ -134,6 +136,30 @@ func TestGetRegistryIndex(t *testing.T) {
 			name:    "Not a URL",
 			url:     serverIP,
 			wantErr: true,
+		},
+		{
+			name: "Get Registry Index with invalid httpTimeout value",
+			url:  "http://" + serverIP,
+			options: RegistryOptions{
+				HTTPTimeout: &invalidHTTPTimeout,
+				Filter: RegistryFilter{
+					Architectures: []string{"amd64", "arm64"},
+				},
+			},
+			devfileTypes: []indexSchema.DevfileType{indexSchema.SampleDevfileType},
+			wantSchemas:  archFilteredIndex,
+		},
+		{
+			name: "Get Registry Index with valid httpTimeout value",
+			url:  "http://" + serverIP,
+			options: RegistryOptions{
+				HTTPTimeout: &validHTTPTimeout,
+				Filter: RegistryFilter{
+					Architectures: []string{"amd64", "arm64"},
+				},
+			},
+			devfileTypes: []indexSchema.DevfileType{indexSchema.SampleDevfileType},
+			wantSchemas:  archFilteredIndex,
 		},
 	}
 


### PR DESCRIPTION
Signed-off-by: Kim Tsao <ktsao@redhat.com>

**Please specify the area for this PR**

**What does does this PR do / why we need it**:

**Which issue(s) this PR fixes**:

- This combines the fixes from both https://github.com/devfile/api#926 and https://github.com/devfile/api/issues/897
- 4.9 specific branch is needed because helm did not backport their changes to this release.  Cherry picking 4.10 changes will result in dependency incompatibilities since oras package was updated 4.10 but not in 4.9


Fixes #?

https://github.com/devfile/api/issues/934

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?
We need to rely on console QE to test

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?
N/A

**How to test changes / Special notes to the reviewer**:
