### PR TITLE
Bump 'manusa/actions-setup-minikube@v2.4.2' to 'v2.7.1'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,7 +93,7 @@ jobs:
         with:
           go-version: 1.17
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.2
+        uses: manusa/actions-setup-minikube@v2.7.1
         with:
           minikube version: 'v1.21.0'
           kubernetes version: 'v1.21.0'


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

ci
registry

**What does does this PR do / why we need it**: This version bump to the GitHub action fixes the OS incompatibility error related to the tied issue.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#991

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
