### PR TITLE
Object property name changes for `NEXT_PUBLIC_DEVFILE_REGISTRIES`

### DIFF
--- a/deploy/chart/devfile-registry/templates/configmap.yaml
+++ b/deploy/chart/devfile-registry/templates/configmap.yaml
@@ -46,6 +46,6 @@ data:
     [
       { 
         "name": "Community", 
-        "link": "http://localhost:8080" 
+        "url": "http://localhost:8080" 
       }
     ]


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

**What does does this PR do / why we need it**: Recent changes to the Registry Viewer now needs the following object property name changes within the JSON stored in the environment variable `NEXT_PUBLIC_DEVFILE_REGISTRIES`:
- `link` is now `url`
- `alias` is now `fqdn`

**Which issue(s) this PR fixes**:

Fixes #?

part of devfile/api#747

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
