### PR TITLE
Registry Viewer envfile configmap

### DIFF
--- a/deploy/chart/devfile-registry/templates/configmap.yaml
+++ b/deploy/chart/devfile-registry/templates/configmap.yaml
@@ -42,10 +42,6 @@ data:
         prometheus:
           enabled: true
           path: /metrics
-  devfile-registry-hosts.json: |
-    [
-      { 
-        "name": "Community", 
-        "url": "http://localhost:8080" 
-      }
-    ]
+  .env.registry-viewer: |
+    ANALYTICS_WRITE_KEY={{ .Values.telemetry.registryViewerWriteKey }}
+    DEVFILE_REGISTRIES=[{"name":"Community","url":"http://localhost:8080","fqdn":"http://devfile-registry-default.{{ .Values.global.ingress.domain }}"}]

--- a/deploy/chart/devfile-registry/templates/configmap.yaml
+++ b/deploy/chart/devfile-registry/templates/configmap.yaml
@@ -44,4 +44,4 @@ data:
           path: /metrics
   .env.registry-viewer: |
     ANALYTICS_WRITE_KEY={{ .Values.telemetry.registryViewerWriteKey }}
-    DEVFILE_REGISTRIES=[{"name":"Community","url":"http://localhost:8080","fqdn":"http://devfile-registry-default.{{ .Values.global.ingress.domain }}"}]
+    DEVFILE_REGISTRIES=[{"name":"Community","url":"http://localhost:8080","fqdn":"http://{{ .Release.Name }}-{{ .Release.Namespace }}.{{ .Values.global.ingress.domain }}"}]

--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -52,6 +52,12 @@ spec:
             items:
               - key: registry-config.yml
                 path: config.yml
+        - name: viewer-env-file
+          configMap:
+            name: {{ template "devfileregistry.fullname" . }}
+            items:
+              - key: .env.registry-viewer
+                path: .env.local
 
       containers:
       - image: "{{ .Values.devfileIndex.image }}:{{ .Values.devfileIndex.tag }}"
@@ -121,16 +127,10 @@ spec:
             memory: {{ .Values.registryViewer.memoryLimit }}
           requests:
             memory: 64Mi
-        env:
-          - name: NEXT_PUBLIC_BASE_PATH
-            value: /viewer
-          - name: NEXT_PUBLIC_DEVFILE_REGISTRIES
-            valueFrom:
-              configMapKeyRef:
-                name: {{ template "devfileregistry.fullname" . }}
-                key: devfile-registry-hosts.json
-          - name: NEXT_PUBLIC_ANALYTICS_WRITE_KEY
-            value: {{ .Values.telemetry.registryViewerWriteKey }}
+        volumeMounts:
+          - name: viewer-env-file
+            mountPath: /app/apps/registry-viewer/.env.local
+            subPath: .env.local
       {{- end }}
       - image: "{{ .Values.ociRegistry.image }}:{{ .Values.ociRegistry.tag }}"
         imagePullPolicy: {{ .Values.ociRegistry.imagePullPolicy }}

--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -58,7 +58,6 @@ spec:
             items:
               - key: .env.registry-viewer
                 path: .env.local
-
       containers:
       - image: "{{ .Values.devfileIndex.image }}:{{ .Values.devfileIndex.tag }}"
         imagePullPolicy: {{ .Values.devfileIndex.imagePullPolicy }}
@@ -93,6 +92,13 @@ spec:
             value: {{ .Values.telemetry.key }}
           - name: REGISTRY_HEADLESS
             value: "{{ .Values.global.headless }}"
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: "RuntimeDefault"
       {{- if not .Values.global.headless }}
       - image: "{{ .Values.registryViewer.image }}:{{ .Values.registryViewer.tag }}"
         imagePullPolicy: {{ .Values.registryViewer.imagePullPolicy }}
@@ -131,6 +137,14 @@ spec:
           - name: viewer-env-file
             mountPath: /app/apps/registry-viewer/.env.local
             subPath: .env.local
+            readOnly: true
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: "RuntimeDefault"
       {{- end }}
       - image: "{{ .Values.ociRegistry.image }}:{{ .Values.ociRegistry.tag }}"
         imagePullPolicy: {{ .Values.ociRegistry.imagePullPolicy }}
@@ -157,6 +171,13 @@ spec:
             memory: {{ .Values.ociRegistry.memoryLimit }}
           requests:
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: "RuntimeDefault"
         volumeMounts:
         - name: devfile-registry-storage
           mountPath: "/var/lib/registry"


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:

Replaces environment variable definitions for the registry viewer with environment variable file content in the `configmap.yaml`for the helm chart, this is a requirement for the registry viewer analytics write key to be set.

**Additional Changes**

Sets the required security context for the registry viewer container, currently needed for OpenShift 4.12 deployments.

**Which issue(s) this PR fixes**:

Fixes #?

part of devfile/api#747

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
