### PR TITLE
Set OCI registry and index server images to use non-root numeric active users

### DIFF
--- a/index/server/Dockerfile
+++ b/index/server/Dockerfile
@@ -19,7 +19,7 @@ RUN chgrp -R 0 /registry && \
 
 # Create a non-root user to run the server as
 RUN set -x ; \
-    adduser www-data -u 82 -G root && exit 0
+    adduser www-data -u 1001 -G root && exit 0
 
 # Modify the permissions on the necessary files to allow the container to properly run as a non-root UID
 RUN mkdir -p /www/data && chmod -R g+rwx /www/data
@@ -34,7 +34,7 @@ ENV DEVFILE_SAMPLE_BASE64_INDEX /www/data/sample_base64_index.json
 ENV DEVFILE_STACK_INDEX /www/data/stack_index.json
 ENV DEVFILE_STACK_BASE64_INDEX /www/data/stack_base64_index.json
 
-USER www-data
+USER 1001
 
 EXPOSE 8080
 

--- a/oci-registry/Dockerfile
+++ b/oci-registry/Dockerfile
@@ -3,7 +3,12 @@ FROM registry:2 as registry
 FROM registry.access.redhat.com/ubi8-minimal:8.2
 RUN microdnf update -y && rm -rf /var/cache/yum && microdnf install ca-certificates httpd-tools
 
-COPY --from=registry /bin/registry /bin/registry
+# Create a non-root user to run the server as
+RUN set -x ; \
+    adduser registry -u 1001 -G root && exit 0
+
+COPY --from=registry --chown=registry:0 /bin/registry /bin/registry
+USER 1001
 EXPOSE 5000
 ENTRYPOINT ["registry"]
 CMD ["serve", "/etc/docker/registry/config.yml"]


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**
oci-registry
index-server

**What does does this PR do / why we need it**:

Changes active users of the images `oci-registry` and `devfile-index-base` to use uid `1001` and set group permissions to `0`. These changes fix container deployment errors in minikube when using the `runAsNonRoot` security context.

**Which issue(s) this PR fixes**:

Fixes #?

part of devfile/api#747

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
