### PR TITLE
Add directory check for multi-version stack packaging

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -77,8 +77,10 @@ build_registry() {
     if [[ -f "stack.yaml" ]]; then
       for versionDir in $stackDir/*
       do
-        cd $versionDir
-        tar_files_and_cleanup
+        if [[ -d "${versionDir}" ]]; then
+          cd $versionDir
+          tar_files_and_cleanup
+        fi
       done
     else
       tar_files_and_cleanup


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

registry

**What does does this PR do / why we need it**:

Fixes a bug in `/build-tools/build.sh` where `tar_files_and_cleanup` can run on files outside of the version directories in a multi-version stack. This results in stacks with missing `archive.tar` files which have resources files needed for devfile/api#1002.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1002

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
