### PR TITLE
Add telemetry for the `download-starter-project` endpoint to registry server

### DIFF
--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/index/server/pkg/server/index.go
+++ b/index/server/pkg/server/index.go
@@ -1,5 +1,5 @@
 //
-// Copyright 2022 Red Hat, Inc.
+// Copyright 2022-2023 Red Hat, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/index/server/pkg/server/index.go
+++ b/index/server/pkg/server/index.go
@@ -41,9 +41,10 @@ import (
 )
 
 var eventTrackMap = map[string]string{
-	"list":     "list devfile",
-	"view":     "view devfile",
-	"download": "download devfile",
+	"list":       "list devfile",
+	"view":       "view devfile",
+	"download":   "download devfile",
+	"spdownload": "Starter Project Downloaded",
 }
 
 var mediaTypeMapping = map[string]string{


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

registry

**What does does this PR do / why we need it**:

Before, the download starter project process was only done in the registry viewer which tracked this telemetry metric itself https://github.com/devfile/registry-viewer/blob/145a485893b726808be40e1e31cc1ec96a8dde96/src/components/DevfilePage/DevfilePageProjects/DevfilePageProjects.tsx#L85.

In recent changes, the registry viewer no longer handles this process itself and instead uses an endpoint on the registry server (devfile/api#720). In addition, the registry viewer no longer tracks starter project downloads since devfile/api#747 was closed and therefore telemetry on starter project downloads needs to be tracked on the server endpoint itself. This PR provides these changes to resolve devfile/api#803.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#803

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
