### PR TITLE
update golang version for integration tests

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,5 +1,5 @@
 #
-#   Copyright 2021-2022 Red Hat, Inc.
+#   Copyright 2021-2023 Red Hat, Inc.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
 #   you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-FROM quay.io/openshift-pipeline/golang:1.15-alpine AS builder
+FROM golang:1.17-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache git bash curl zip


### PR DESCRIPTION
Signed-off-by: Kim Tsao <ktsao@redhat.com>

**Please specify the area for this PR**
registry tests

**What does does this PR do / why we need it**:
Integration tests are building a test image based off a deprecated go base image.  Updated to match the version we are using to build our production image

**Which issue(s) this PR fixes**:

Fixes #?

https://github.com/devfile/api/issues/1008

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
