### PR TITLE
Probe changes in helm chart template

### DIFF
--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -79,7 +79,15 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
-          timeoutSeconds: 3         
+          timeoutSeconds: 3
+        startupProbe:
+          httpGet:
+            path: /viewer
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 1
+          timeoutSeconds: 10          
         resources:
           limits:
             memory: {{ .Values.devfileIndex.memoryLimit }}
@@ -103,31 +111,7 @@ spec:
       - image: "{{ .Values.registryViewer.image }}:{{ .Values.registryViewer.tag }}"
         imagePullPolicy: {{ .Values.registryViewer.imagePullPolicy }}
         name: registry-viewer
-        ports:
-        livenessProbe:
-          httpGet:
-            path: /viewer
-            port: 3000
-            scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 10
-          timeoutSeconds: 3
-        readinessProbe:
-          httpGet:
-            path: /viewer
-            port: 3000
-            scheme: HTTP
-          initialDelaySeconds: 15
-          periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          httpGet:
-            path: /viewer
-            port: 3000
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 1
-          timeoutSeconds: 10  
+        ports: 
         resources:
           limits:
             memory: {{ .Values.registryViewer.memoryLimit }}


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

registry

**What does does this PR do / why we need it**:

Updates the probing in the helm chart deployment template to ensure the registry index server is ready before launching the registry viewer.

**Which issue(s) this PR fixes**:

Fixes #?

part of devfile/api#1019

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
