### PR TITLE
Fix environment variable definitions for registry viewer deployment

### DIFF
--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -57,7 +57,7 @@ spec:
             name: {{ template "devfileregistry.fullname" . }}
             items:
               - key: .env.registry-viewer
-                path: .env.local
+                path: .env.production
       containers:
       - image: "{{ .Values.devfileIndex.image }}:{{ .Values.devfileIndex.tag }}"
         imagePullPolicy: {{ .Values.devfileIndex.imagePullPolicy }}
@@ -133,10 +133,22 @@ spec:
             memory: {{ .Values.registryViewer.memoryLimit }}
           requests:
             memory: 64Mi
+        env:
+          - name: ANALYTICS_WRITE_KEY
+            value: {{ .Values.telemetry.registryViewerWriteKey }}
+          - name: DEVFILE_REGISTRIES
+            value: |
+              [
+                {
+                  "name": "Community",
+                  "url": "http://localhost:8080",
+                  "fqdn": "http://{{ .Release.Name }}-{{ .Release.Namespace }}.{{ .Values.global.ingress.domain }}"
+                }
+              ]
         volumeMounts:
           - name: viewer-env-file
-            mountPath: /app/apps/registry-viewer/.env.local
-            subPath: .env.local
+            mountPath: /app/.env.production
+            subPath: .env.production
             readOnly: true
         securityContext:
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

registry

**What does does this PR do / why we need it**:

Provides required fixes to setting environment variables on the registry viewer deployment within the helm chart template.

**Which issue(s) this PR fixes**:

Fixes #?

part of devfile/api#1016

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
