### PR TITLE
No `startupProbe` if in headless mode

### DIFF
--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -80,6 +80,7 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 10
           timeoutSeconds: 3
+        {{- if not .Values.global.headless }}
         startupProbe:
           httpGet:
             path: /viewer
@@ -87,7 +88,8 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 30
           periodSeconds: 1
-          timeoutSeconds: 10          
+          timeoutSeconds: 10
+        {{- end }}
         resources:
           limits:
             memory: {{ .Values.devfileIndex.memoryLimit }}


### PR DESCRIPTION
Signed-off-by: Michael Valdron <mvaldron@redhat.com>

**Please specify the area for this PR**

registry

**What does does this PR do / why we need it**:

This change includes a required if block in the helm chart deployment template for headless mode which omits the `startupProbe` in the registry index server deployment which probes the registry viewer. This change was missing from #159.

**Which issue(s) this PR fixes**:

Fixes #?

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
