### PR TITLE
feat(index/generator): adding command groups to index schema

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -374,6 +374,33 @@ func parseStackDevfile(devfileDirPath string, stackName string, force bool, vers
 	versionComponent.Links["self"] = fmt.Sprintf("%s/%s:%s", "devfile-catalog", stackName, versionComponent.Version)
 	versionComponent.SchemaVersion = devfile.SchemaVersion
 
+	kinds := []schema.CommandGroupKind{
+		schema.BuildCommandGroupKind,
+		schema.RunCommandGroupKind,
+		schema.TestCommandGroupKind,
+		schema.DebugCommandGroupKind,
+		schema.DeployCommandGroupKind,
+	}
+
+	if versionComponent.CommandGroups == nil {
+		versionComponent.CommandGroups = make(map[schema.CommandGroupKind]bool)
+		for _, kind := range kinds {
+			versionComponent.CommandGroups[kind] = false
+		}
+	}
+
+	for _, commands := range devfile.Commands {
+		if commands.Exec.Group.Kind != "" {
+			versionComponent.CommandGroups[commands.Exec.Group.Kind] = true
+		}
+		if commands.Apply.Group.Kind != "" {
+			versionComponent.CommandGroups[commands.Apply.Group.Kind] = true
+		}
+		if commands.Composite.Group.Kind != "" {
+			versionComponent.CommandGroups[commands.Composite.Group.Kind] = true
+		}
+	}
+
 	for _, starterProject := range devfile.StarterProjects {
 		versionComponent.StarterProjects = append(versionComponent.StarterProjects, starterProject.Name)
 	}

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -98,6 +98,13 @@ Sample index file:
         "resources": [
           "devfile.yaml"
         ],
+		"commandGroups": {
+		  "build": true,
+		  "run": true,
+		  "test": false,
+		  "debug": false,
+		  "deploy": false
+		},
         "starterProjects": [
           "community",
           "redhat-product"
@@ -122,6 +129,7 @@ globalMemoryLimit: string - The devfile global memory limit
 projectType: string - The project framework that is used in the devfile
 language: string - The project language that is used in the devfile
 links: map[string]string - Links related to the devfile
+commandGroups: map[CommandGroupKind]bool - The command groups that are used in the devfile
 resources: []string - The file resources that compose a devfile stack.
 starterProjects: string[] - The project templates that can be used in the devfile
 git: *git - The information of remote repositories
@@ -131,25 +139,26 @@ versions: []Version - The list of stack versions information
 
 // Schema is the index file schema
 type Schema struct {
-	Name              string                 `yaml:"name,omitempty" json:"name,omitempty"`
-	Version           string                 `yaml:"version,omitempty" json:"version,omitempty"`
-	Attributes        map[string]apiext.JSON `yaml:"attributes,omitempty" json:"attributes,omitempty"`
-	DisplayName       string                 `yaml:"displayName,omitempty" json:"displayName,omitempty"`
-	Description       string                 `yaml:"description,omitempty" json:"description,omitempty"`
-	Type              DevfileType            `yaml:"type,omitempty" json:"type,omitempty"`
-	Tags              []string               `yaml:"tags,omitempty" json:"tags,omitempty"`
-	Architectures     []string               `yaml:"architectures,omitempty" json:"architectures,omitempty"`
-	Icon              string                 `yaml:"icon,omitempty" json:"icon,omitempty"`
-	GlobalMemoryLimit string                 `yaml:"globalMemoryLimit,omitempty" json:"globalMemoryLimit,omitempty"`
-	ProjectType       string                 `yaml:"projectType,omitempty" json:"projectType,omitempty"`
-	Language          string                 `yaml:"language,omitempty" json:"language,omitempty"`
-	Links             map[string]string      `yaml:"links,omitempty" json:"links,omitempty"`
-	Resources         []string               `yaml:"resources,omitempty" json:"resources,omitempty"`
-	StarterProjects   []string               `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
-	Git               *Git                   `yaml:"git,omitempty" json:"git,omitempty"`
-	Provider          string                 `yaml:"provider,omitempty" json:"provider,omitempty"`
-	SupportUrl        string                 `yaml:"supportUrl,omitempty" json:"supportUrl,omitempty"`
-	Versions          []Version              `yaml:"versions,omitempty" json:"versions,omitempty"`
+	Name              string                    `yaml:"name,omitempty" json:"name,omitempty"`
+	Version           string                    `yaml:"version,omitempty" json:"version,omitempty"`
+	Attributes        map[string]apiext.JSON    `yaml:"attributes,omitempty" json:"attributes,omitempty"`
+	DisplayName       string                    `yaml:"displayName,omitempty" json:"displayName,omitempty"`
+	Description       string                    `yaml:"description,omitempty" json:"description,omitempty"`
+	Type              DevfileType               `yaml:"type,omitempty" json:"type,omitempty"`
+	Tags              []string                  `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Architectures     []string                  `yaml:"architectures,omitempty" json:"architectures,omitempty"`
+	Icon              string                    `yaml:"icon,omitempty" json:"icon,omitempty"`
+	GlobalMemoryLimit string                    `yaml:"globalMemoryLimit,omitempty" json:"globalMemoryLimit,omitempty"`
+	ProjectType       string                    `yaml:"projectType,omitempty" json:"projectType,omitempty"`
+	Language          string                    `yaml:"language,omitempty" json:"language,omitempty"`
+	Links             map[string]string         `yaml:"links,omitempty" json:"links,omitempty"`
+	CommandGroups     map[CommandGroupKind]bool `yaml:"commandGroups,omitempty" json:"commandGroups,omitempty"`
+	Resources         []string                  `yaml:"resources,omitempty" json:"resources,omitempty"`
+	StarterProjects   []string                  `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	Git               *Git                      `yaml:"git,omitempty" json:"git,omitempty"`
+	Provider          string                    `yaml:"provider,omitempty" json:"provider,omitempty"`
+	SupportUrl        string                    `yaml:"supportUrl,omitempty" json:"supportUrl,omitempty"`
+	Versions          []Version                 `yaml:"versions,omitempty" json:"versions,omitempty"`
 }
 
 // DevfileType describes the type of devfile
@@ -163,15 +172,46 @@ const (
 	StackDevfileType DevfileType = "stack"
 )
 
+// CommandGroupKind describes the kind of command group
+type CommandGroupKind string
+
+const (
+	BuildCommandGroupKind  CommandGroupKind = "build"
+	RunCommandGroupKind    CommandGroupKind = "run"
+	TestCommandGroupKind   CommandGroupKind = "test"
+	DebugCommandGroupKind  CommandGroupKind = "debug"
+	DeployCommandGroupKind CommandGroupKind = "deploy"
+)
+
 // StarterProject is the devfile starter project
 type StarterProject struct {
 	Name string `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+// Commands stores the command information
+type Commands struct {
+	Id        string      `yaml:"id,omitempty" json:"id,omitempty"`
+	Exec      CommandType `yaml:"exec,omitempty" json:"exec,omitempty"`
+	Apply     CommandType `yaml:"apply,omitempty" json:"apply,omitempty"`
+	Composite CommandType `yaml:"composite,omitempty" json:"composite,omitempty"`
+}
+
+// CommandType stores the group for a command
+type CommandType struct {
+	Group CommandGroup `yaml:"group,omitempty" json:"group,omitempty"`
+}
+
+// CommandGroup stores the group information for a command
+type CommandGroup struct {
+	Kind      CommandGroupKind `yaml:"kind,omitempty" json:"kind,omitempty"`
+	IsDefault bool             `yaml:"isDefault,omitempty" json:"isDefault,omitempty"`
 }
 
 // Devfile is the devfile structure that is used by index component
 type Devfile struct {
 	Meta            Schema           `yaml:"metadata,omitempty" json:"metadata,omitempty"`
 	StarterProjects []StarterProject `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	Commands        []Commands       `yaml:"commands,omitempty" json:"commands,omitempty"`
 	SchemaVersion   string           `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty"`
 }
 
@@ -190,7 +230,7 @@ type ExtraDevfileEntries struct {
 	Stacks  []Schema `yaml:"stacks,omitempty" json:"stacks,omitempty"`
 }
 
-// Version stores the top-level stack information defined within stack.yaml
+// StackInfo stores the top-level stack information defined within stack.yaml
 type StackInfo struct {
 	Name        string    `yaml:"name,omitempty" json:"name,omitempty"`
 	DisplayName string    `yaml:"displayName,omitempty" json:"displayName,omitempty"`
@@ -201,15 +241,16 @@ type StackInfo struct {
 
 // Version stores the information for each stack version
 type Version struct {
-	Version         string            `yaml:"version,omitempty" json:"version,omitempty"`
-	SchemaVersion   string            `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty"`
-	Default         bool              `yaml:"default,omitempty" json:"default,omitempty"`
-	Git             *Git              `yaml:"git,omitempty" json:"git,omitempty"`
-	Description     string            `yaml:"description,omitempty" json:"description,omitempty"`
-	Tags            []string          `yaml:"tags,omitempty" json:"tags,omitempty"`
-	Architectures   []string          `yaml:"architectures,omitempty" json:"architectures,omitempty"`
-	Icon            string            `yaml:"icon,omitempty" json:"icon,omitempty"`
-	Links           map[string]string `yaml:"links,omitempty" json:"links,omitempty"`
-	Resources       []string          `yaml:"resources,omitempty" json:"resources,omitempty"`
-	StarterProjects []string          `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	Version         string                    `yaml:"version,omitempty" json:"version,omitempty"`
+	SchemaVersion   string                    `yaml:"schemaVersion,omitempty" json:"schemaVersion,omitempty"`
+	Default         bool                      `yaml:"default,omitempty" json:"default,omitempty"`
+	Git             *Git                      `yaml:"git,omitempty" json:"git,omitempty"`
+	Description     string                    `yaml:"description,omitempty" json:"description,omitempty"`
+	Tags            []string                  `yaml:"tags,omitempty" json:"tags,omitempty"`
+	Architectures   []string                  `yaml:"architectures,omitempty" json:"architectures,omitempty"`
+	Icon            string                    `yaml:"icon,omitempty" json:"icon,omitempty"`
+	Links           map[string]string         `yaml:"links,omitempty" json:"links,omitempty"`
+	CommandGroups   map[CommandGroupKind]bool `yaml:"commandGroups,omitempty" json:"commandGroups,omitempty"`
+	Resources       []string                  `yaml:"resources,omitempty" json:"resources,omitempty"`
+	StarterProjects []string                  `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
 }

--- a/index/generator/tests/registry/index_main.json
+++ b/index/generator/tests/registry/index_main.json
@@ -20,7 +20,14 @@
           "self": "devfile-catalog/go:1.2.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["go-starter"]
+        "starterProjects": ["go-starter"],
+        "commandGroups": {
+          "build": true,
+          "debug": false,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       },
       {
         "version": "1.1.0",
@@ -33,7 +40,14 @@
           "self": "devfile-catalog/go:1.1.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["go-starter"]
+        "starterProjects": ["go-starter"],
+        "commandGroups": {
+          "build": true,
+          "debug": false,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -57,7 +71,14 @@
           "self": "devfile-catalog/java-maven:1.1.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["springbootproject"]
+        "starterProjects": ["springbootproject"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -79,7 +100,14 @@
           "self": "devfile-catalog/java-openliberty:0.5.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["user-app"]
+        "starterProjects": ["user-app"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": true
+        }
       }
     ]
   },
@@ -103,7 +131,14 @@
           "self": "devfile-catalog/java-quarkus:1.1.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["community", "redhat-product"]
+        "starterProjects": ["community", "redhat-product"],
+        "commandGroups": {
+          "build": false,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -128,7 +163,14 @@
           "self": "devfile-catalog/java-springboot:1.1.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["springbootproject"]
+        "starterProjects": ["springbootproject"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -171,7 +213,14 @@
           "vertx-configmap-example-redhat",
           "vertx-messaging-work-queue-booster",
           "vertx-istio-distributed-tracing-booster"
-        ]
+        ],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -203,7 +252,14 @@
           "microprofile-openapi",
           "microprofile-opentracing",
           "microprofile-rest-client"
-        ]
+        ],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -243,7 +299,14 @@
           "microprofile-openapi",
           "microprofile-opentracing",
           "microprofile-rest-client"
-        ]
+        ],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -266,7 +329,14 @@
           "self": "devfile-catalog/nodejs:1.0.0"
         },
         "resources": ["archive.tar", "devfile.yaml"],
-        "starterProjects": ["nodejs-starter"]
+        "starterProjects": ["nodejs-starter"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": true
+        }
       }
     ]
   },
@@ -289,7 +359,14 @@
           "self": "devfile-catalog/python:1.0.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["python-example"]
+        "starterProjects": ["python-example"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -312,7 +389,14 @@
           "self": "devfile-catalog/python-django:1.0.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["django-example"]
+        "starterProjects": ["django-example"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },

--- a/index/generator/tests/registry/index_registry.json
+++ b/index/generator/tests/registry/index_registry.json
@@ -20,7 +20,14 @@
           "self": "devfile-catalog/go:1.2.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["go-starter"]
+        "starterProjects": ["go-starter"],
+        "commandGroups": {
+          "build": true,
+          "debug": false,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       },
       {
         "version": "1.1.0",
@@ -33,7 +40,14 @@
           "self": "devfile-catalog/go:1.1.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["go-starter"]
+        "starterProjects": ["go-starter"],
+        "commandGroups": {
+          "build": true,
+          "debug": false,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -57,7 +71,14 @@
           "self": "devfile-catalog/java-maven:1.1.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["springbootproject"]
+        "starterProjects": ["springbootproject"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -79,7 +100,14 @@
           "self": "devfile-catalog/java-openliberty:0.5.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["user-app"]
+        "starterProjects": ["user-app"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": true
+        }
       }
     ]
   },
@@ -103,7 +131,14 @@
           "self": "devfile-catalog/java-quarkus:1.1.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["community", "redhat-product"]
+        "starterProjects": ["community", "redhat-product"],
+        "commandGroups": {
+          "build": false,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -128,7 +163,14 @@
           "self": "devfile-catalog/java-springboot:1.1.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["springbootproject"]
+        "starterProjects": ["springbootproject"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -171,7 +213,14 @@
           "vertx-configmap-example-redhat",
           "vertx-messaging-work-queue-booster",
           "vertx-istio-distributed-tracing-booster"
-        ]
+        ],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -203,7 +252,14 @@
           "microprofile-openapi",
           "microprofile-opentracing",
           "microprofile-rest-client"
-        ]
+        ],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -243,7 +299,14 @@
           "microprofile-openapi",
           "microprofile-opentracing",
           "microprofile-rest-client"
-        ]
+        ],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -266,7 +329,14 @@
           "self": "devfile-catalog/nodejs:1.0.0"
         },
         "resources": ["archive.tar", "devfile.yaml"],
-        "starterProjects": ["nodejs-starter"]
+        "starterProjects": ["nodejs-starter"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": true
+        }
       }
     ]
   },
@@ -289,7 +359,14 @@
           "self": "devfile-catalog/python:1.0.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["python-example"]
+        "starterProjects": ["python-example"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   },
@@ -312,7 +389,14 @@
           "self": "devfile-catalog/python-django:1.0.0"
         },
         "resources": ["devfile.yaml"],
-        "starterProjects": ["django-example"]
+        "starterProjects": ["django-example"],
+        "commandGroups": {
+          "build": true,
+          "debug": true,
+          "deploy": false,
+          "run": true,
+          "test": false
+        }
       }
     ]
   }


### PR DESCRIPTION
Signed-off-by: Michael Hoang <mhoang@redhat.com>

**Please specify the area for this PR**
index/generator

**What does does this PR do / why we need it**:
Adds the command groups defined in the devfile stack to the registry index.

After this PR is merged, the index server needs to be:
* updated with the index/generator version that contains the schema change
* updated with the new index response in the docs

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/996

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
* build the image with the changes using `build_registry`
* deploy image to a cluster and check the /v2index endpoint

<img width="815" alt="Screenshot 2023-02-13 at 8 05 04 PM" src="https://user-images.githubusercontent.com/35011707/218766201-1cc7eb6a-54f7-4a93-ba3f-dd91b7d6be18.png">
<img width="833" alt="Screenshot 2023-02-13 at 8 07 36 PM" src="https://user-images.githubusercontent.com/35011707/218766206-613118bb-4e68-4869-b636-eb5c09a5b818.png">

