### PR TITLE
Add liveness and readiness probes to registry viewer container in the helm chart

### DIFF
--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -114,6 +114,22 @@ spec:
         imagePullPolicy: {{ .Values.registryViewer.imagePullPolicy }}
         name: registry-viewer
         ports: 
+        livenessProbe:
+          httpGet:
+            path: /viewer
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 3
+        readinessProbe:
+          httpGet:
+            path: /viewer
+            port: 3000
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 10
+          timeoutSeconds: 3
         resources:
           limits:
             memory: {{ .Values.registryViewer.memoryLimit }}


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:

Adds missing required probes removed in devfile/api#1019.

**Which issue(s) this PR fixes**:

Fixes #?

part of devfile/api#1040

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
