### PR TITLE
Add registry probing to integration test suite

### DIFF
--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,7 +14,13 @@ To build the test binary locally, run: `./build.sh`
 
 ## Custom Tests
 
+### Specific Registries
+
 Some tests like using the arch filter are registry specific. For example, the community registry may not have devfiles with archs mentioned but the test registry in this repo does. As such, run these specific tests by setting the env  `IS_TEST_REGISTRY=true`
+
+### Registry Probing
+
+Optionally, a health check probe can be run to require the target registry to be at a ready status. This can be enabled by setting the env `PROBE_TIMEOUT`, to have the probe timeout in 30 seconds set the env to `PROBE_TIMEOUT=30`.
 
 ## Run in a Container
 

--- a/tests/integration/cmd/devfileregistry_test.go
+++ b/tests/integration/cmd/devfileregistry_test.go
@@ -61,8 +61,6 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 			fmt.Println(err)
 			panic(err)
 		}
-	} else {
-		config.IsTestRegistry = false
 	}
 
 	// If timeout duration until readiness probe runs out is set, run readiness probe

--- a/tests/integration/cmd/devfileregistry_test.go
+++ b/tests/integration/cmd/devfileregistry_test.go
@@ -1,4 +1,4 @@
-/*   Copyright 2021-2022 Red Hat, Inc.
+/*   Copyright 2021-2023 Red Hat, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/devfile/registry-support/tests/integration/pkg/config"
+	"github.com/devfile/registry-support/tests/integration/pkg/util"
 
 	_ "github.com/devfile/registry-support/tests/integration/pkg/tests"
 	"github.com/onsi/ginkgo"
@@ -38,6 +39,8 @@ const (
 
 //SynchronizedBeforeSuite blocks is executed before run all test suites
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
+	var err error
+
 	fmt.Println("Starting to setup objects before run ginkgo suite")
 	registry := os.Getenv("REGISTRY")
 	if registry == "" {
@@ -45,9 +48,36 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 	}
 	config.Registry = registry
 	config.RegistryList = registry + "," + "https://registry.stage.devfile.io"
-	os.Setenv("REGISTRY_LIST", config.RegistryList)
+	err = os.Setenv("REGISTRY_LIST", config.RegistryList)
+	if err != nil {
+		fmt.Println(err)
+		panic(err)
+	}
 
-	config.IsTestRegistry, _ = strconv.ParseBool(os.Getenv("IS_TEST_REGISTRY"))
+	// If the registry is the test one, set IsTestRegistry variable to run extra test cases
+	if isTestRegistry, isSet := os.LookupEnv("IS_TEST_REGISTRY"); isSet {
+		config.IsTestRegistry, err = strconv.ParseBool(isTestRegistry)
+		if err != nil {
+			fmt.Println(err)
+			panic(err)
+		}
+	} else {
+		config.IsTestRegistry = false
+	}
+
+	// If timeout duration until readiness probe runs out is set, run readiness probe
+	if timeout, isSet := os.LookupEnv("PROBE_TIMEOUT"); isSet {
+		probeTimeout, err := strconv.Atoi(timeout)
+		if err != nil {
+			fmt.Println(err)
+			panic(err)
+		}
+
+		if err = util.ProbeRegistry(config.Registry, probeTimeout); err != nil {
+			fmt.Println(err)
+			panic(err)
+		}
+	}
 
 	return nil
 }, func(data []byte) {})

--- a/tests/integration/pkg/tests/indexserver_tests.go
+++ b/tests/integration/pkg/tests/indexserver_tests.go
@@ -73,7 +73,8 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 		gomega.Expect(body).To(gomega.ContainSubstring("<!DOCTYPE html>"))
 
 		// Verify that the registry viewer's page has been properly generated
-		gomega.Expect(body).To(gomega.ContainSubstring("A simple Hello World Node.js application"))
+		gomega.Expect(body).To(gomega.ContainSubstring("Devfile Registry"))
+		gomega.Expect(body).To(gomega.ContainSubstring("Devfile, OpenShift, Kubernetes"))
 	})
 
 	ginkgo.It("/index endpoint should return list of stacks", func() {


### PR DESCRIPTION
**Please specify the area for this PR**

integration tests

**What does does this PR do / why we need it**:

Add the optional ability to enforce a successful health check probe on the target registry in order to run tests. This feature is required to fix staging deployment problems due to the acceptance testing running before the deployment is ready.

**Additional Changes**
- Registry viewer test case has been revised to work with the new registry viewer content
- Error handling has been added for the getting and setting of environment variables


**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1086

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:

1. Build the container image
    ```sh
    bash docker-build.sh
    ```
2. Run the container against a deploying target registry with the `PROBE_TIMEOUT` environment variable set
    ```sh
    docker run --rm --env REGISTRY=$REGISTRY --env PROBE_TIMEOUT=60 devfile-registry-integration
    ```