### PR TITLE
Update directly executed scripts on workflows and scripts

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -31,7 +31,7 @@ COPY tests/registry /registry
 RUN bash /build-tools/dl_starter_projects.sh go-starter community
 
 # Run the registry build tools
-RUN /build-tools/build.sh /registry /build
+RUN bash /build-tools/build.sh /registry /build
 
 FROM devfile-index-base
 

--- a/.ci/run_tests_minikube_linux.sh
+++ b/.ci/run_tests_minikube_linux.sh
@@ -12,7 +12,7 @@ set -u
 set -x
 
 # Build the test devfile registry image
-./build_registry.sh
+bash ./build_registry.sh
 if [ $? -ne 0 ]; then
   echo "Error building devfile registry images"
   exit 1;
@@ -40,5 +40,5 @@ export REGISTRY=http://$(kubectl get ingress devfile-registry -o jsonpath="{.spe
 
 # Run the integration tests
 cd tests/integration
-./docker-build.sh
+bash ./docker-build.sh
 docker run --env REGISTRY=$REGISTRY --env IS_TEST_REGISTRY=true devfile-registry-integration

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: |
           export PATH=$PATH:$(go env GOPATH)/bin
           go install github.com/securego/gosec/v2/cmd/gosec@v2.14.0
-          ./run_gosec.sh
+          bash ./run_gosec.sh
           if [[ $? != 0 ]]
           then
             echo "gosec scanner failed to run "

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Issue tracking repo: https://github.com/devfile/api with label area/registry
 If you want to run the build scripts with Podman, set the environment variable
 `export USE_PODMAN=true`
 
-To build all of the components together (recommended) for dev/test, run `./build_registry.sh` to build a Devfile Registry index image that is populated with the mock devfile registry data under `tests/registry/`.
+To build all of the components together (recommended) for dev/test, run `bash ./build_registry.sh` to build a Devfile Registry index image that is populated with the mock devfile registry data under `tests/registry/`.
 
 Once the container has been pushed, you can push it to a container registry of your choosing with the following commands:
 

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -13,6 +13,6 @@ This folder contains tools for building up a Devfile Registry Repository and pac
 
 ### Building the Devfile Registry
 
-To build a devfile registry repository, run: `./build_image.sh <path-to-devfile-registry-folder>`.
+To build a devfile registry repository, run: `bash ./build_image.sh <path-to-devfile-registry-folder>`.
 
 The build script will build the index generator, generate the index.json from the specified devfile registry, and build the stacks and index.json into a devfile index container image.

--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -61,7 +61,7 @@ build_registry() {
 
   # Build the index generator/validator
   echo "Building index-generator tool"
-  ./build.sh
+  bash ./build.sh
   if [ $? -ne 0 ]; then
     echo "Failed to build index-generator tool"
     return 1
@@ -92,7 +92,7 @@ build_registry() {
   # Cache any devfile samples if needed
   if [ -f $registryRepository/extraDevfileEntries.yaml ]; then
     mkdir $outputFolder/samples
-    $buildToolsFolder/cache_samples.sh $registryRepository/extraDevfileEntries.yaml $outputFolder/samples
+    bash $buildToolsFolder/cache_samples.sh $registryRepository/extraDevfileEntries.yaml $outputFolder/samples
     if [ $? -ne 0 ]; then
       echo "Error caching the devfile samples"
       exit 1;

--- a/build-tools/build_image.sh
+++ b/build-tools/build_image.sh
@@ -35,7 +35,7 @@ if [ $# -ne 1 ]; then
   exit 1
 fi
 
-$buildToolsFolder/build.sh $1 $registryFolder
+bash $buildToolsFolder/build.sh $1 $registryFolder
 if [ $? -ne 0 ]; then
   echo "Failed to build the devfile registry index"
   cleanup_and_exit 1

--- a/index/server/Dockerfile
+++ b/index/server/Dockerfile
@@ -38,4 +38,4 @@ USER 1001
 
 EXPOSE 8080
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["bash /entrypoint.sh"]

--- a/index/server/Dockerfile
+++ b/index/server/Dockerfile
@@ -38,4 +38,4 @@ USER 1001
 
 EXPOSE 8080
 
-ENTRYPOINT ["bash /entrypoint.sh"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/index/server/Dockerfile
+++ b/index/server/Dockerfile
@@ -11,6 +11,7 @@ USER root
 # Install and configure dependencies
 RUN microdnf update -y && microdnf install shadow-utils findutils && rm -rf /var/cache/yum
 COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
 
 # Copy index server
 COPY --from=index-builder /tools/index-server /registry/index-server


### PR DESCRIPTION
**Please specify the area for this PR**

/area ci

**What does does this PR do / why we need it**:

It ensures that all script executions, inside `.github/workflows` and inside scripts code, are not directly executed and that the script file is passed to the appropriate shell defined by the scripts shebang. For example. in the case of a bash script ./build.sh would become bash ./build.sh.

**Which issue(s) this PR fixes**:

fixes https://github.com/devfile/api/issues/973

Fixes #?

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [x] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [x] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
