### PR TITLE
Schema version validation changes

### DIFF
--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -428,21 +428,21 @@ func buildIndexAPIResponse(c *gin.Context, wantV1Index bool) {
 		maxSchemaVersion := c.Query("maxSchemaVersion")
 		if maxSchemaVersion != "" || minSchemaVersion != "" {
 			// check if schema version filters are in valid format.
-			// should only include major and minor version. e.g. 2.1
+			// should include major and minor versions as well as an optional bugfix version. e.g. 2.1 or 2.1.0
 			if minSchemaVersion != "" {
-				matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)$`, minSchemaVersion)
+				matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)(\.[0-9]+)?$`, minSchemaVersion)
 				if !matched || err != nil {
-					c.JSON(http.StatusInternalServerError, gin.H{
-						"status": fmt.Sprintf("minSchemaVersion %s is not valid, should only include major and minor version. %v", minSchemaVersion, err),
+					c.JSON(http.StatusBadRequest, gin.H{
+						"status": fmt.Sprintf("minSchemaVersion %s is not valid, version format should be '[major].[minor]' or '[major].[minor].[bugfix]'. %v", minSchemaVersion, err),
 					})
 					return
 				}
 			}
 			if maxSchemaVersion != "" {
-				matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)$`, maxSchemaVersion)
+				matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)(\.[0-9]+)?$`, maxSchemaVersion)
 				if !matched || err != nil {
-					c.JSON(http.StatusInternalServerError, gin.H{
-						"status": fmt.Sprintf("maxSchemaVersion %s is not valid, should only include major and minor version. %v", maxSchemaVersion, err),
+					c.JSON(http.StatusBadRequest, gin.H{
+						"status": fmt.Sprintf("maxSchemaVersion %s is not valid, version format should be '[major].[minor]' or '[major].[minor].[bugfix]'. %v", maxSchemaVersion, err),
 					})
 					return
 				}
@@ -538,21 +538,21 @@ func fetchDevfile(c *gin.Context, name string, version string) ([]byte, indexSch
 		minSchemaVersion := c.Query("minSchemaVersion")
 		maxSchemaVersion := c.Query("maxSchemaVersion")
 		// check if schema version filters are in valid format.
-		// should only include major and minor version. e.g. 2.1
+		// should include major and minor versions as well as an optional bugfix version. e.g. 2.1 or 2.1.0
 		if minSchemaVersion != "" {
-			matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)$`, minSchemaVersion)
+			matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)(\.[0-9]+)?$`, minSchemaVersion)
 			if !matched || err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"status": fmt.Sprintf("minSchemaVersion %s is not valid, should only include major and minor version. %v", minSchemaVersion, err),
+				c.JSON(http.StatusBadRequest, gin.H{
+					"status": fmt.Sprintf("minSchemaVersion %s is not valid, version format should be '[major].[minor]' or '[major].[minor].[bugfix]'. %v", minSchemaVersion, err),
 				})
 				return []byte{}, indexSchema.Schema{}
 			}
 		}
 		if maxSchemaVersion != "" {
-			matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)$`, maxSchemaVersion)
+			matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)(\.[0-9]+)?$`, maxSchemaVersion)
 			if !matched || err != nil {
-				c.JSON(http.StatusInternalServerError, gin.H{
-					"status": fmt.Sprintf("maxSchemaVersion %s is not valid, should only include major and minor version. %v", maxSchemaVersion, err),
+				c.JSON(http.StatusBadRequest, gin.H{
+					"status": fmt.Sprintf("maxSchemaVersion %s is not valid, version format should be '[major].[minor]' or '[major].[minor].[bugfix]'. %v", maxSchemaVersion, err),
 				})
 				return []byte{}, indexSchema.Schema{}
 			}

--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -433,7 +433,7 @@ func buildIndexAPIResponse(c *gin.Context, wantV1Index bool) {
 				matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)(\.[0-9]+)?$`, minSchemaVersion)
 				if !matched || err != nil {
 					c.JSON(http.StatusBadRequest, gin.H{
-						"status": fmt.Sprintf("minSchemaVersion %s is not valid, version format should be '[major].[minor]' or '[major].[minor].[bugfix]'. %v", minSchemaVersion, err),
+						"status": fmt.Sprintf("minSchemaVersion %s is not valid, version format should be '+2.x' or '+2.x.x'. %v", minSchemaVersion, err),
 					})
 					return
 				}
@@ -442,7 +442,7 @@ func buildIndexAPIResponse(c *gin.Context, wantV1Index bool) {
 				matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)(\.[0-9]+)?$`, maxSchemaVersion)
 				if !matched || err != nil {
 					c.JSON(http.StatusBadRequest, gin.H{
-						"status": fmt.Sprintf("maxSchemaVersion %s is not valid, version format should be '[major].[minor]' or '[major].[minor].[bugfix]'. %v", maxSchemaVersion, err),
+						"status": fmt.Sprintf("maxSchemaVersion %s is not valid, version format should be '+2.x' or '+2.x.x'. %v", maxSchemaVersion, err),
 					})
 					return
 				}
@@ -543,7 +543,7 @@ func fetchDevfile(c *gin.Context, name string, version string) ([]byte, indexSch
 			matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)(\.[0-9]+)?$`, minSchemaVersion)
 			if !matched || err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{
-					"status": fmt.Sprintf("minSchemaVersion %s is not valid, version format should be '[major].[minor]' or '[major].[minor].[bugfix]'. %v", minSchemaVersion, err),
+					"status": fmt.Sprintf("minSchemaVersion %s is not valid, version format should be '+2.x' or '+2.x.x'. %v", minSchemaVersion, err),
 				})
 				return []byte{}, indexSchema.Schema{}
 			}
@@ -552,7 +552,7 @@ func fetchDevfile(c *gin.Context, name string, version string) ([]byte, indexSch
 			matched, err := regexp.MatchString(`^([2-9])\.([0-9]+)(\.[0-9]+)?$`, maxSchemaVersion)
 			if !matched || err != nil {
 				c.JSON(http.StatusBadRequest, gin.H{
-					"status": fmt.Sprintf("maxSchemaVersion %s is not valid, version format should be '[major].[minor]' or '[major].[minor].[bugfix]'. %v", maxSchemaVersion, err),
+					"status": fmt.Sprintf("maxSchemaVersion %s is not valid, version format should be '+2.x' or '+2.x.x'. %v", maxSchemaVersion, err),
 				})
 				return []byte{}, indexSchema.Schema{}
 			}

--- a/tests/integration/pkg/tests/indexserver_tests.go
+++ b/tests/integration/pkg/tests/indexserver_tests.go
@@ -234,13 +234,25 @@ var _ = ginkgo.Describe("[Verify index server is working properly]", func() {
 		}
 	})
 
-	ginkgo.It("/v2index?arch=amd64&arch=arm64 endpoint should return stacks for devfile schema version 2.1.x", func() {
+	ginkgo.It("/v2index?minSchemaVersion=2.1&maxSchemaVersion=2.1 endpoint should return stacks for devfile schema version 2.1.0", func() {
 		registryIndex := util.GetRegistryIndex(config.Registry + "/v2index/all?minSchemaVersion=2.1&maxSchemaVersion=2.1")
 
 		for _, index := range registryIndex {
 			if len(index.Versions) != 0 {
 				for _, version := range index.Versions {
-					gomega.Expect(version.SchemaVersion).Should(gomega.HavePrefix("2.1"))
+					gomega.Expect(version.SchemaVersion).Should(gomega.Equal("2.1.0"))
+				}
+			}
+		}
+	})
+
+	ginkgo.It("/v2index?minSchemaVersion=2.1.0&maxSchemaVersion=2.1.0 endpoint should return stacks for devfile schema version 2.1.0", func() {
+		registryIndex := util.GetRegistryIndex(config.Registry + "/v2index/all?minSchemaVersion=2.1.0&maxSchemaVersion=2.1.0")
+
+		for _, index := range registryIndex {
+			if len(index.Versions) != 0 {
+				for _, version := range index.Versions {
+					gomega.Expect(version.SchemaVersion).Should(gomega.Equal("2.1.0"))
 				}
 			}
 		}


### PR DESCRIPTION
**Please specify the area for this PR**

index server

**What does does this PR do / why we need it**:

Changes contain the following:
* schema version validation error response code changed from 500 internal server to 400 bad request
* optional bugfix version allowed, e.g. both `2.2` and `2.2.0` are accepted schema versions

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1128

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
