### PR TITLE
Add build section to index server README

### DIFF
--- a/index/server/README.md
+++ b/index/server/README.md
@@ -6,6 +6,40 @@ Provides REST API support for devfile registries and serves [devfile registry vi
 
 For more information on REST API docs: [registry-REST-API.adoc](registry-REST-API.adoc)
 
+## Build
+
+The registry index server is built into a container image, `devfile-index-base:latest`, by running the following script:
+
+```sh
+bash index/server/build.sh
+```
+
+You retag it with one of the two command:
+
+**Docker CLI**
+
+```sh
+docker tag devfile-index-base:latest <new-image-tag>
+```
+
+**Podman CLI**
+
+```sh
+podman tag devfile-index-base:latest <new-image-tag>
+```
+
+Push your image into the an image repository with the following:
+
+```sh
+bash index/server/push.sh <new-image-tag>
+```
+
+For example, if the image repository is quay.io then use the pattern `quay.io/<user>/devfile-index-base`:
+
+```sh
+bash index/server/push.sh quay.io/someuser/devfile-index-base
+```
+
 ## Testing
 
 Endpoint unit testing is defined under `pkg/server/endpoint_test.go` and can be performed by running the following:


### PR DESCRIPTION
**Please specify the area for this PR**

index server
documentation

**What does does this PR do / why we need it**:

Adds instructions on how to build the index server container image `devfile-index-base`, re-tag it, and push it to an image repository.

**Which issue(s) this PR fixes**:

Fixes #?

part of devfile/api#1131

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
