### PR TITLE
adding build scripts to extract stack resources

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -27,6 +27,9 @@ COPY build-tools /build-tools
 COPY index/ /index
 COPY tests/registry /registry
 
+# Download all the offline parent devfiles
+RUN bash /build-tools/dl_parent_devfiles.sh
+
 # Download offline starter projects
 RUN bash /build-tools/dl_starter_projects.sh go-starter community
 

--- a/build-tools/dl_parent_devfiles.sh
+++ b/build-tools/dl_parent_devfiles.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+# Path of stacks directory in the registry
+STACKS_DIR=${STACKS_DIR:-/registry/stacks}
+
+# Downloads the parent devfile to be used as an offline resource
+download_parent_devfile() {
+    local stack_root=$1
+    local name=$2
+    local parent_devfile_uri=$3
+    parent_devfile=${name}-parent.devfile.yaml
+
+    if [ ! -f $stack_root/$parent_devfile ]; then
+        curl -L $parent_devfile_uri -o $stack_root/$parent_devfile || return 1
+    fi
+}
+
+# Updates the uri to the downloaded offline parent devfile
+replace_parent_devfile() {
+    local stack_root=$1
+    local name=$2
+    local parent_devfile_uri=$3
+    stack_devfile=$stack_root/devfile.yaml
+    parent_devfile=../${name}-parent.devfile.yaml
+
+    if [ -f $stack_root/$parent_devfile ]; then
+        export PARENT_DEVFILE=$parent_devfile
+        yq e -i ".parent.uri=env(PARENT_DEVFILE)" $stack_devfile
+    fi
+}
+
+download_and_replace() {
+    for stack in ${stacks[@]}
+    do
+        if [ $stack == "OWNERS" ]; then
+            continue
+        fi
+        stack_root=$STACKS_DIR/$stack
+        stack_devfile=$stack_root/devfile.yaml
+        # Read version list for stack
+        versions=($([ -f ${STACKS_DIR}/${stack}/stack.yaml ] && yq e '.versions.[].version' ${STACKS_DIR}/${stack}/stack.yaml))
+        # Multi version stack
+        if [[ ${#versions[@]} -gt 0 ]]
+        then
+            for version in ${versions[@]}
+            do
+                stack_root=$STACKS_DIR/$stack/$version
+                stack_devfile=$stack_root/devfile.yaml
+                name="$(yq e ".metadata.name" $stack_devfile)"
+                parent_devfile_uri="$(yq e ".parent.uri" $stack_devfile)"
+
+                if [ "$parent_devfile_uri" != "null" ]
+                then
+                    echo "Downloading parent devfile in stack ${stack} version ${version}.."
+                    download_parent_devfile $stack_root $name $parent_devfile_uri
+                    if [ $? -eq 0 ]; then
+                        replace_parent_devfile $stack_root $name $parent_devfile_uri
+                    fi
+                    echo "Downloading parent devfile in stack ${stack} version ${version}..done!"
+                fi
+            done
+        # Not a multi version stack
+        else
+            name="$(yq e ".metadata.name" $stack_devfile)"
+            parent_devfile_uri="$(yq e ".parent.uri" $stack_devfile)"
+
+            if [ "$parent_devfile_uri" != "null" ]
+            then
+                echo "Downloading parent devfile in stack ${stack}.."
+                download_parent_devfile $stack_root $name $parent_devfile_uri
+                if [ $? -eq 0 ]; then
+                    replace_parent_devfile $stack_root $name $parent_devfile_uri
+                fi
+                echo "Downloading parent devfile in stack ${stack}..done!"
+            fi
+        fi
+    done
+}
+
+# Read stacks list
+read -r -a stacks <<< "$(ls ${STACKS_DIR} | tr '\n' ' ')"
+
+echo "Downloading parent devfiles.."
+download_and_replace
+echo "Downloading parent devfiles..done!"

--- a/build-tools/extract_resources.sh
+++ b/build-tools/extract_resources.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Path of stacks directory in the registry
+STACKS_DIR=${STACKS_DIR:-/build/stacks}
+
+extract() {
+    local stack_root=$1
+    if [[ -f "$stack_root/archive.tar" ]]
+    then
+        tar -xf "$stack_root/archive.tar" -C "$stack_root"
+        echo "Successfully extracted archive.tar"
+    else
+        echo "Skipping... no archive.tar found"
+    fi
+}
+
+registry=$1
+
+read -r -a stacks <<< "$(ls ${STACKS_DIR} | tr '\n' ' ')"
+
+for stack in ${stacks[@]}
+do
+    stack_root=$STACKS_DIR/$stack
+    stack_archive=$stack_root/archive.tar
+
+    # Read version list for stack
+    versions=($([ -f ${STACKS_DIR}/${stack}/stack.yaml ] && yq e '.versions.[].version' ${STACKS_DIR}/${stack}/stack.yaml))
+
+    # Multi version stack
+    if [[ ${#versions[@]} -gt 0 ]]
+    then
+        for version in ${versions[@]}
+            do
+                echo "Extracting archive.tar in stack ${stack} version ${version}.."
+                extract "$stack_root/$version"
+            done
+    # Not a multi version
+    else
+        echo "Extracting archive.tar in stack ${stack}.."
+        extract $stack_root
+    fi
+done

--- a/tests/registry/stacks/go/2.1.0/devfile.yaml
+++ b/tests/registry/stacks/go/2.1.0/devfile.yaml
@@ -1,0 +1,14 @@
+schemaVersion: 2.2.0
+metadata:
+  description: "Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
+  displayName: Go Runtime
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg
+  name: go
+  projectType: Go
+  provider: Red Hat
+  language: Go
+  tags:
+    - Go
+  version: 2.1.0
+parent:
+  uri: https://registry.devfile.io/devfiles/go/2.1.0

--- a/tests/registry/stacks/go/stack.yaml
+++ b/tests/registry/stacks/go/stack.yaml
@@ -7,3 +7,4 @@ versions:
   - version: 1.2.0
     default: true # should have one and only one default version
   - version: 2.0.0
+  - version: 2.1.0


### PR DESCRIPTION
**Please specify the area for this PR**

/area registry

**What does does this PR do / why we need it**:

Adds `extract_resources.sh`
- Extracts the archive.tar inside the stack directory which contains outerloop resources that are referenced by the devfiles

Adds `dl_parent_devfiles.sh`
- Downloads all parent uri devfiles and updates the child devfile to point to the downloaded parent

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/1220

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [x] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [x] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
To test locally:
1. Update the `STACK_DIR` to `STACKS_DIR=tests/registry/stacks`
2. Run the scripts; `bash /registry-support/build-tools/extract_resources.sh`, `bash /registry-support/build-tools/dl_parent_devfiles.sh`

To test with the registry build script:
- Run the build script from: https://github.com/devfile/registry/pull/197
- `bash build.sh offline`

Verify that resources are inside the stack:
- `docker run --rm -it --entrypoint bash devfile-index`
- `cd /registry/stacks/`
