### PR TITLE
Update build instructions to include a specific version for oapi-codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Issue tracking repo: https://github.com/devfile/api with label area/registry
 
 ## Build
 
+### Prerequisite
+
+The current release relies on [oapi-codegen 1.12.4](https://github.com/deepmap/oapi-codegen/tree/v1.12.4). See the [Index Server README](index/server/README.md) for more information.
+
+To install, run:
+`go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@1.12.4`
+
+### Instructions
 If you want to run the build scripts with Podman, set the environment variable
 `export USE_PODMAN=true`
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Issue tracking repo: https://github.com/devfile/api with label area/registry
 
 ### Prerequisite
 
-The current release relies on [oapi-codegen 1.12.4](https://github.com/deepmap/oapi-codegen/tree/v1.12.4). See the [Index Server README](index/server/README.md) for more information.
+The current release relies on [oapi-codegen 1.12.4](https://github.com/deepmap/oapi-codegen/tree/v1.12.4) for OpenAPI source generation. See the [Index Server README](index/server/README.md#source-generation) for more information.
 
 To install, run:
 `go install github.com/deepmap/oapi-codegen/cmd/oapi-codegen@1.12.4`


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
Updates the build instruction to specify the compatible version 1.12.4

**Which issue(s) this PR fixes**:

Fixes #?
https://github.com/devfile/api/issues/1253

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes? N/A

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes? N/A
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes? 

**How to test changes / Special notes to the reviewer**:
