### PR TITLE
Add only default tags in indexComponent

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -441,9 +441,11 @@ func parseStackDevfile(devfileDirPath string, stackName string, force bool, vers
 		versionComponent.StarterProjects = append(versionComponent.StarterProjects, starterProject.Name)
 	}
 
-	for _, tag := range versionComponent.Tags {
-		if !inArray(indexComponent.Tags, tag) {
-			indexComponent.Tags = append(indexComponent.Tags, tag)
+	if versionComponent.Default {
+		for _, tag := range versionComponent.Tags {
+			if !inArray(indexComponent.Tags, tag) {
+				indexComponent.Tags = append(indexComponent.Tags, tag)
+			}
 		}
 	}
 

--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -295,12 +295,11 @@ func parseDevfileRegistry(registryDirPath string, force bool) ([]schema.Schema, 
 				}
 			}
 		} else { // if stack.yaml not exist, old stack repo struct, directly lookfor & parse devfile.yaml
-			versionComponent := schema.Version{}
+			versionComponent := schema.Version{Default: true}
 			err := parseStackDevfile(stackFolderPath, stackFolderDir.Name(), force, &versionComponent, &indexComponent)
 			if err != nil {
 				return nil, err
 			}
-			versionComponent.Default = true
 			indexComponent.Versions = append(indexComponent.Versions, versionComponent)
 		}
 		indexComponent.Type = schema.StackDevfileType

--- a/index/generator/tests/registry/index_main.json
+++ b/index/generator/tests/registry/index_main.json
@@ -4,7 +4,7 @@
     "displayName": "Go Runtime",
     "description": "Stack with the latest Go version",
     "type": "stack",
-    "tags": ["testtag", "Go"],
+    "tags": ["Go"],
     "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
     "projectType": "go",
     "language": "go",

--- a/index/generator/tests/registry/index_registry.json
+++ b/index/generator/tests/registry/index_registry.json
@@ -4,7 +4,7 @@
     "displayName": "Go Runtime",
     "description": "Stack with the latest Go version",
     "type": "stack",
-    "tags": ["testtag", "Go"],
+    "tags": ["testtag"],
     "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
     "projectType": "go",
     "language": "go",

--- a/index/generator/tests/registry/index_registry.json
+++ b/index/generator/tests/registry/index_registry.json
@@ -4,7 +4,7 @@
     "displayName": "Go Runtime",
     "description": "Stack with the latest Go version",
     "type": "stack",
-    "tags": ["testtag"],
+    "tags": ["Go"],
     "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
     "projectType": "go",
     "language": "go",


### PR DESCRIPTION
**Please specify the area for this PR**

/area registry

**What does does this PR do / why we need it**:

The PR updates the `index` tags generation process. More specifically it only adds the `default` version tags into each `indexComponent` instead of adding all the tags from all versions.

This update fixes the issue of having `Deprecated` stack version. For example, if one version of a stack is deprecated (so it has the Deprecated tag) then in the `v2index/all` endpoint we will have the `Deprecated` tag representing all versions.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/1289

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [x] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [x] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
