### PR TITLE
Vulnerability Fix

### DIFF
--- a/registry-library/library/util.go
+++ b/registry-library/library/util.go
@@ -113,7 +113,7 @@ func decompress(targetDir string, tarFile string, excludeFiles []string) error {
 			continue
 		}
 
-		target := path.Join(targetDir, filepath.Clean(header.Name))
+		target := CleanFilepath(targetDir, header.Name)
 		switch header.Typeflag {
 		case tar.TypeDir:
 			err = os.MkdirAll(target, os.FileMode(header.Mode))
@@ -191,4 +191,11 @@ func getHTTPClient(options RegistryOptions) *http.Client {
 		},
 		Timeout: overriddenTimeout,
 	}
+}
+
+// Cleans a child path to ensure that there is no escaping from the parent directory with the use of ../ escape methods
+// Ensures that the child path is always contained and absolutely pathed from the parent
+func CleanFilepath(parent string, child string)string{
+	target := path.Join(parent, filepath.Clean("/"+child))
+	return target
 }

--- a/registry-library/library/util.go
+++ b/registry-library/library/util.go
@@ -122,7 +122,6 @@ func decompress(targetDir string, tarFile string, excludeFiles []string) error {
 				return returnedErr
 			}
 		case tar.TypeReg:
-			/* #nosec G304 -- target is produced using path.Join which cleans the dir path */
 			w, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				returnedErr = multierror.Append(returnedErr, err)

--- a/registry-library/library/util_test.go
+++ b/registry-library/library/util_test.go
@@ -18,6 +18,7 @@ package library
 import (
 	"reflect"
 	"testing"
+	"strings"
 )
 
 func TestValidateStackVersionTag(t *testing.T) {
@@ -126,6 +127,85 @@ func TestSplitVersionFromStack(t *testing.T) {
 				t.Errorf("Expected Stack Name: %+v, \nGot Stack Name: %+v", test.wantStack, gotStack)
 			} else if !reflect.DeepEqual(gotVersion, test.wantVersion) {
 				t.Errorf("Expected Version: %+v, \nGot Version: %+v", test.wantVersion, gotVersion)
+			}
+		})
+	}
+}
+
+func TestCleanFilepath(t *testing.T) {
+	tests := []struct {
+		name       		string
+		parentPath   	string
+		childPath 		string
+		expectedPath 	string
+	}{
+		{
+			name:       "Absolute child path with leading slash",
+			parentPath: ".",
+			childPath: "/test/tmp",
+			expectedPath: "test/tmp",
+		},
+		{
+			name:       "Absolute child path without leading slash",
+			parentPath: ".",
+			childPath: "test/tmp",
+			expectedPath: "test/tmp",
+		},
+		{
+			name:       "Relative child path without leading slash",
+			parentPath: ".",
+			childPath: "../../../../test/tmp",
+			expectedPath: "test/tmp",
+		},
+		{
+			name:       "Relative child path with leading slash",
+			parentPath: ".",
+			childPath: "/../../../../test/tmp",
+			expectedPath: "test/tmp",
+		},
+		{
+			name:       "Absolute child path with leading slash and escape capabilities",
+			parentPath: ".",
+			childPath: "/home/../../../../test/tmp",
+			expectedPath: "test/tmp",
+		},
+		{
+			name:       "Absolute child path with leading slash and escape capabilities (parent path not current dir)",
+			parentPath: "newHome/dir",
+			childPath: "/home/../../../../test/tmp",
+			expectedPath: "newHome/dir/test/tmp",
+		},
+		{
+			name:       "Relative child path without leading slash and escape capabilities (parent path not current dir)",
+			parentPath: "newHome/dir",
+			childPath: "../home/../../../../test/tmp",
+			expectedPath: "newHome/dir/test/tmp",
+		},
+		{
+			name:       "Blank child path",
+			parentPath: "dir",
+			childPath: "",
+			expectedPath: "dir",
+		},
+		{
+			name:       "Child path only escape characters",
+			parentPath: "dir",
+			childPath: "../../../../../",
+			expectedPath: "dir",
+		},
+		{
+			name:       "Single file as child path",
+			parentPath: "dir",
+			childPath: "test.txt",
+			expectedPath: "dir/test.txt",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			path:= CleanFilepath(test.parentPath, test.childPath)
+			if !strings.EqualFold(test.expectedPath, path) {
+				t.Errorf("Expected: %s, Got: %s", test.expectedPath, path)
 			}
 		})
 	}


### PR DESCRIPTION
**Please specify the area for this PR**
Vulnerability fixes

**What does does this PR do / why we need it**:
This PR aims to add a fix that ensures no malicious files can be added to an `archive.tar` file that is being read. Currently the `filepath.Join` and `filepath.Clean` functions are not properly accounting for paths added in a relative fashion (ie. "../../filename") and only properly cleans file paths that start with a leading slash. This fix adds that leading slash to all filepaths (relative or absolute) before the cleaning process, this ensures that no filepath can leave the confines of its parent by escaping out. The cleaning process removes any redundant double slashes that may arise because we are prepending the leading slash.

**Which issue(s) this PR fixes**:

No public issue

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
