### PR TITLE
Fix error related to directory does not exist

### DIFF
--- a/build-tools/build.sh
+++ b/build-tools/build.sh
@@ -70,8 +70,8 @@ build_registry() {
   cd "$OLDPWD"
 
   # Generate the tar archive
-  for stackDir in $outputFolder/stacks/*
-  do
+  for stackDir in $outputFolder/stacks/*; do
+  if [[ -d "${stackDir}" ]]; then
     cd $stackDir
     if [[ -f "stack.yaml" ]]; then
       for versionDir in $stackDir/*
@@ -85,6 +85,7 @@ build_registry() {
       tar_files_and_cleanup
     fi
     cd "$OLDPWD"
+  fi
   done
   cd "$buildToolsDir"
 


### PR DESCRIPTION
**Please specify the area for this PR**
Bug fix

**What does does this PR do / why we need it**:
This PR adds a check to make sure that before performing a `cd` command we verify that `$stackDir` is a directory and not a file. Previous to this check it was attempting to perform `cd OWNERS` where `OWNERS` is a file, subsequently throwing an error/warning during the build process.

**Which issue(s) this PR fixes**:
fixes https://github.com/devfile/api/issues/1207


**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
While trying to test the changes for this fix I was running into issues with running the `build.sh` script locally. I opened a spike issue to investigate if anything can be changed for this. https://github.com/devfile/api/issues/1447

