### PR TITLE
Fix devfile registry entry name and ingress url

### DIFF
--- a/deploy/chart/devfile-registry/templates/_template.tpl
+++ b/deploy/chart/devfile-registry/templates/_template.tpl
@@ -17,6 +17,15 @@
 {{- .Values.hostnameOverride | default (printf "devfile-registry-%s" .Release.Namespace) -}}
 {{- end -}}
 
+{{- define "devfileregistry.ingressUrl" -}}
+{{- $hostname := .Values.hostnameOverride | default (printf "devfile-registry-%s" .Release.Namespace) -}}
+{{- if .Values.global.tlsEnabled -}}
+{{- .Values.global.ingress.domain | printf "https://%s.%s" $hostname -}}
+{{- else -}}
+{{- .Values.global.ingress.domain | printf "http://%s.%s" $hostname -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "devfileregistry.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/deploy/chart/devfile-registry/templates/_template.tpl
+++ b/deploy/chart/devfile-registry/templates/_template.tpl
@@ -17,6 +17,11 @@
 {{- .Values.hostnameOverride | default (printf "devfile-registry-%s" .Release.Namespace) -}}
 {{- end -}}
 
+{{- define "devfileregistry.ingressHostname" -}}
+{{- $hostname := .Values.hostnameOverride | default (printf "devfile-registry-%s" .Release.Namespace) -}}
+{{- .Values.global.ingress.domain | printf "%s.%s" $hostname -}}
+{{- end -}}
+
 {{- define "devfileregistry.ingressUrl" -}}
 {{- $hostname := .Values.hostnameOverride | default (printf "devfile-registry-%s" .Release.Namespace) -}}
 {{- if .Values.global.tlsEnabled -}}

--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -142,9 +142,9 @@ spec:
             value: |
               [
                 {
-                  "name": "Community",
+                  "name": "{{ template "devfileregistry.name" . }}",
                   "url": "http://localhost:8080",
-                  "fqdn": "http://{{ .Release.Name }}-{{ .Release.Namespace }}.{{ .Values.global.ingress.domain }}"
+                  "fqdn": "{{ template "devfileregistry.ingressUrl" . }}"
                 }
               ]
         volumeMounts:

--- a/deploy/chart/devfile-registry/templates/ingress.yaml
+++ b/deploy/chart/devfile-registry/templates/ingress.yaml
@@ -26,7 +26,7 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.global.ingress.class }}
 spec:
   rules:
-  - host: {{ template "devfileregistry.ingressUrl" . }}
+  - host: {{ template "devfileregistry.ingressHostname" . }}
     http:
       paths:
       - path: /

--- a/deploy/chart/devfile-registry/templates/ingress.yaml
+++ b/deploy/chart/devfile-registry/templates/ingress.yaml
@@ -26,7 +26,7 @@ metadata:
     kubernetes.io/ingress.class: {{ .Values.global.ingress.class }}
 spec:
   rules:
-  - host: {{ template "devfileregistry.hostname" . -}} . {{- .Values.global.ingress.domain }}
+  - host: {{ template "devfileregistry.ingressUrl" . }}
     http:
       paths:
       - path: /


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:

Fixes the devfile registry entry name for registry viewer component of the helm chart. Fixed name 'Community' changed to value of `{{ template "devfileregistry.name" . }}` (the deployment name).

Additionally, the ingress url is now define and built under `_template.tpl`: https://github.com/michael-valdron/devfile-registry-support/blob/1df84bc08021587d954a3f6749699d77b40aaf28/deploy/chart/devfile-registry/templates/_template.tpl#L20-L27

Currently, this is only built from the ingress domain for k8s and devfile/api#1467 needs resolving to either separate this field or not rely on manually setting the domain for OpenShift environments.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1433

**PR acceptance criteria**:

- [X] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
