### PR TITLE
Helm Specs Update

### DIFF
--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -87,8 +87,8 @@ spec:
             port: 3000
             scheme: HTTP
           initialDelaySeconds: 30
-          periodSeconds: 1
-          timeoutSeconds: 10
+          periodSeconds: 10
+          timeoutSeconds: 20
         {{- end }}
         resources:
           limits:
@@ -121,7 +121,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 20
         readinessProbe:
           httpGet:
             path: /viewer
@@ -129,7 +129,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: 15
           periodSeconds: 10
-          timeoutSeconds: 3
+          timeoutSeconds: 20
         resources:
           limits:
             memory: {{ .Values.registryViewer.memoryLimit }}

--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -38,6 +38,13 @@ spec:
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
     spec:
+      {{- if .Values.persistence.enabled }}
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1001
+        runAsGroup: 2001
+        fsGroup: 3001
+      {{- end }}
       volumes:
         - name: devfile-registry-storage
         {{- if .Values.persistence.enabled }}
@@ -52,12 +59,6 @@ spec:
             items:
               - key: registry-config.yml
                 path: config.yml
-        - name: viewer-env-file
-          configMap:
-            name: {{ template "devfileregistry.fullname" . }}
-            items:
-              - key: .env.registry-viewer
-                path: .env.production
       containers:
       - image: "{{ .Values.devfileIndex.image }}:{{ .Values.devfileIndex.tag }}"
         imagePullPolicy: {{ .Values.devfileIndex.imagePullPolicy }}
@@ -147,11 +148,6 @@ spec:
                   "fqdn": "{{ template "devfileregistry.ingressUrl" . }}"
                 }
               ]
-        volumeMounts:
-          - name: viewer-env-file
-            mountPath: /app/.env.production
-            subPath: .env.production
-            readOnly: true
         securityContext:
           allowPrivilegeEscalation: false
           runAsNonRoot: true


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
This PR alters the timeout values so that the Helm deployment and operator deployment are synced in their values. Additionally it removes the env file mounts as the variables are defined in the spec and it is un-needed. This PR also updates the pod level security context to match that of the operator.

**Which issue(s) this PR fixes**:

fixes https://github.com/devfile/api/issues/1430

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
Deployed Helm chart on both minikube and openshift and verified the security context was applied properly and deployment was successful.