### PR TITLE
Backport (v1.1.x): Fix index generator reference under registry library

### DIFF
--- a/registry-library/go.mod
+++ b/registry-library/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/containerd/containerd v1.6.12
-	github.com/devfile/registry-support/index/generator v0.0.0
+	github.com/devfile/registry-support/index/generator v0.0.0-20240228144139-dd51121eae68
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/go-version v1.4.0
 	github.com/mitchellh/go-homedir v1.1.0
@@ -75,4 +75,4 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 )
 
-replace github.com/devfile/registry-support/index/generator v0.0.0 => ../index/generator
+replace github.com/devfile/registry-support/index/generator v0.0.0-20240228144139-dd51121eae68 => ../index/generator

--- a/registry-library/vendor/modules.txt
+++ b/registry-library/vendor/modules.txt
@@ -26,7 +26,7 @@ github.com/containerd/containerd/remotes/docker/auth
 github.com/containerd/containerd/remotes/docker/schema1
 github.com/containerd/containerd/remotes/errors
 github.com/containerd/containerd/version
-# github.com/devfile/registry-support/index/generator v0.0.0 => ../index/generator
+# github.com/devfile/registry-support/index/generator v0.0.0-20240228144139-dd51121eae68 => ../index/generator
 ## explicit; go 1.18
 github.com/devfile/registry-support/index/generator/schema
 # github.com/docker/cli v20.10.21+incompatible


### PR DESCRIPTION
**Please specify the area for this PR**

registry-library

**What does does this PR do / why we need it**:

Fixes issue with fetching latest revisions of registry library on consumers.

**Which issue(s) this PR fixes**:

Fixes #?

fixes https://github.com/devfile/api/issues/1475

**PR acceptance criteria**:

- [x] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
