### PR TITLE
Set namespace for helm chart template specs

### DIFF
--- a/deploy/chart/devfile-registry/templates/configmap.yaml
+++ b/deploy/chart/devfile-registry/templates/configmap.yaml
@@ -17,6 +17,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "devfileregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "devfileregistry.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -22,6 +22,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   name: {{ template "devfileregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   revisionHistoryLimit: 2

--- a/deploy/chart/devfile-registry/templates/ingress.yaml
+++ b/deploy/chart/devfile-registry/templates/ingress.yaml
@@ -17,6 +17,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "devfileregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "devfileregistry.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/deploy/chart/devfile-registry/templates/pvc.yaml
+++ b/deploy/chart/devfile-registry/templates/pvc.yaml
@@ -18,6 +18,7 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ template "devfileregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ template "devfileregistry.name" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"

--- a/deploy/chart/devfile-registry/templates/route.yaml
+++ b/deploy/chart/devfile-registry/templates/route.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     app: {{ template "devfileregistry.name" . }}
   name: {{ template "devfileregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   to:
     kind: Service

--- a/deploy/chart/devfile-registry/templates/service.yaml
+++ b/deploy/chart/devfile-registry/templates/service.yaml
@@ -22,6 +22,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   name: {{ template "devfileregistry.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: http


### PR DESCRIPTION
**Please specify the area for this PR**

helm chart

**What does does this PR do / why we need it**:

Adds `metadata.namespace` field to all helm chart template specs:
- `configmap.yaml`
- `deployment.yaml`
- `ingress.yaml`
- `pvc.yaml`
- `route.yaml`
- `service.yaml`

This is part of keeping deployments consistent with specs defined under [devfile/registry-operator](https://github.com/devfile/registry-operator).

**Which issue(s) this PR fixes**:

Fixes #?

fixes https://github.com/devfile/api/issues/1432

**PR acceptance criteria**:

- [X] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:

[Deploy with helm chart](https://github.com/devfile/registry-support#via-the-devfile-registry-helm-chart) under any environment to test this out. [Deploy with operator](https://github.com/devfile/registry-support#via-the-devfile-registry-operator) to compare with devfile registry deployments via the [devfile/registry-operator](https://github.com/devfile/registry-operator).
