### PR TITLE
Bring back comment for nosec

### DIFF
--- a/registry-library/library/util.go
+++ b/registry-library/library/util.go
@@ -122,6 +122,7 @@ func decompress(targetDir string, tarFile string, excludeFiles []string) error {
 				return returnedErr
 			}
 		case tar.TypeReg:
+			/* #nosec G304 -- target is produced using path.Join which cleans the dir path */
 			w, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 			if err != nil {
 				returnedErr = multierror.Append(returnedErr, err)
@@ -194,7 +195,7 @@ func getHTTPClient(options RegistryOptions) *http.Client {
 
 // Cleans a child path to ensure that there is no escaping from the parent directory with the use of ../ escape methods
 // Ensures that the child path is always contained and absolutely pathed from the parent
-func CleanFilepath(parent string, child string)string{
+func CleanFilepath(parent string, child string) string {
 	target := path.Join(parent, filepath.Clean("/"+child))
 	return target
 }


### PR DESCRIPTION
**Please specify the area for this PR**

/area registry-library

**What does does this PR do / why we need it**:

This PR simply reverts the removal of the `nosec` comment related to the G304 code here: https://github.com/devfile/registry-support/commit/20ce96dfbc7393e2085b6a7d88879c7ed2c20237

**Which issue(s) this PR fixes**:

N/A

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
