### PR TITLE
Add deprecated stacks filtering to registry-library

### DIFF
--- a/index/generator/tests/registry/index_main.json
+++ b/index/generator/tests/registry/index_main.json
@@ -154,7 +154,7 @@
     "description": "Spring Boot® using Java",
     "type": "stack",
     "tags": ["Java", "Spring"],
-    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
     "projectType": "spring",
     "language": "java",
     "versions": [
@@ -163,7 +163,7 @@
         "schemaVersion": "2.2.0",
         "default": true,
         "description": "Spring Boot® using Java",
-        "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+        "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
         "tags": ["Java", "Spring"],
         "links": {
           "self": "devfile-catalog/java-springboot:1.1.0"

--- a/index/generator/tests/registry/index_registry.json
+++ b/index/generator/tests/registry/index_registry.json
@@ -154,7 +154,7 @@
     "description": "Spring Boot® using Java",
     "type": "stack",
     "tags": ["Java", "Spring"],
-    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
     "projectType": "spring",
     "language": "java",
     "versions": [
@@ -164,7 +164,7 @@
         "default": true,
         "description": "Spring Boot® using Java",
         "tags": ["Java", "Spring"],
-        "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+        "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
         "links": {
           "self": "devfile-catalog/java-springboot:1.1.0"
         },

--- a/index/generator/tests/registry/stacks/java-springboot/devfile.yaml
+++ b/index/generator/tests/registry/stacks/java-springboot/devfile.yaml
@@ -6,7 +6,7 @@ metadata:
   description: Spring Boot® using Java
   tags: ["Java", "Spring"]
   globalMemoryLimit: 2674Mi
-  icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg
   projectType: "spring"
   language: "java"
 starterProjects:

--- a/index/server/pkg/util/index.json
+++ b/index/server/pkg/util/index.json
@@ -101,7 +101,7 @@
       "Java",
       "Spring"
     ],
-    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
     "projectType": "spring",
     "language": "java",
     "links": {

--- a/index/server/registry-REST-API.adoc
+++ b/index/server/registry-REST-API.adoc
@@ -135,7 +135,7 @@ curl http://devfile-registry.192.168.1.1.nip.io/index
       "Java",
       "Spring"
     ],
-    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
     "globalMemoryLimit": "2674Mi",
     "projectType": "spring",
     "language": "java",
@@ -801,7 +801,7 @@ curl http://devfile-registry.192.168.1.1.nip.io/index/all
       "Java",
       "Spring"
     ],
-    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
     "globalMemoryLimit": "2674Mi",
     "projectType": "spring",
     "language": "java",

--- a/index/server/tests/registry/index_main.json
+++ b/index/server/tests/registry/index_main.json
@@ -162,7 +162,7 @@
       "Java",
       "Spring"
     ],
-    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
     "projectType": "spring",
     "language": "java",
     "versions": [
@@ -171,7 +171,7 @@
         "schemaVersion": "2.2.0",
         "default": true,
         "description": "Spring Boot® using Java",
-        "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+        "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
         "tags": [
           "Java",
           "Spring"

--- a/index/server/tests/registry/index_registry.json
+++ b/index/server/tests/registry/index_registry.json
@@ -162,7 +162,7 @@
       "Java",
       "Spring"
     ],
-    "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+    "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
     "projectType": "spring",
     "language": "java",
     "versions": [
@@ -171,7 +171,7 @@
         "schemaVersion": "2.2.0",
         "default": true,
         "description": "Spring Boot® using Java",
-        "icon": "https://www.eclipse.org/che/images/logo-eclipseche.svg",
+        "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
         "tags": [
           "Java",
           "Spring"

--- a/index/server/tests/registry/stacks/java-springboot/devfile.yaml
+++ b/index/server/tests/registry/stacks/java-springboot/devfile.yaml
@@ -6,7 +6,7 @@ metadata:
   description: Spring Boot® using Java
   tags: ["Java", "Spring"]
   globalMemoryLimit: 2674Mi
-  icon: https://www.eclipse.org/che/images/logo-eclipseche.svg
+  icon: https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg
   projectType: "spring"
   language: "java"
 starterProjects:

--- a/registry-library/README.md
+++ b/registry-library/README.md
@@ -128,6 +128,22 @@ Supported devfile media types can be found in the latest version of [library.go]
       HTTPTimeout: &customTimeout
    }
    ```
+7. Filter *only deprecated* Devfiles based on the [lifecycle process for the devfiles project](https://github.com/devfile/registry/blob/main/LIFECYCLE.md)
+    ```go
+    options := registryLibrary.RegistryOptions{
+        Filter: registryLibrary.RegistryFilter{
+            Deprecated: "true",
+        },
+    }
+    ```
+8. Filter *only non deprecated* Devfiles based on the [lifecycle process for the devfiles project](https://github.com/devfile/registry/blob/main/LIFECYCLE.md)
+    ```go
+    options := registryLibrary.RegistryOptions{
+        Filter: registryLibrary.RegistryFilter{
+            Deprecated: "false",
+        },
+    }
+    ```
 
 #### Download the starter project
 

--- a/registry-library/README.md
+++ b/registry-library/README.md
@@ -132,7 +132,7 @@ Supported devfile media types can be found in the latest version of [library.go]
     ```go
     options := registryLibrary.RegistryOptions{
         Filter: registryLibrary.RegistryFilter{
-            Deprecated: "true",
+            Deprecated: registryLibrary.DeprecatedFilterTrue,
         },
     }
     ```
@@ -140,7 +140,7 @@ Supported devfile media types can be found in the latest version of [library.go]
     ```go
     options := registryLibrary.RegistryOptions{
         Filter: registryLibrary.RegistryFilter{
-            Deprecated: "false",
+            Deprecated: registryLibrary.DeprecatedFilterFalse,
         },
     }
     ```

--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -103,6 +103,10 @@ type RegistryFilter struct {
 	// only major version and minor version are required. e.g. 2.1, 2.2 ect. service version should not be provided.
 	// will only be applied if `NewIndexSchema=true`
 	MaxSchemaVersion string
+	// Deprecated is set to filter devfile index for stacks having the "Deprecated" tag inside their default set of tags
+	// or not. the only acceptable values are "true"/"false". in case the value is "true" it will only include only
+	// deprecated stacks, if is "false" only non deprecated. will only be applied if `NewIndexSchema=true`
+	Deprecated string
 }
 
 // GetRegistryIndex returns the list of index schema structured stacks and/or samples from a specified devfile registry.
@@ -152,13 +156,17 @@ func GetRegistryIndex(registryURL string, options RegistryOptions, devfileTypes 
 				q.Add("arch", arch)
 			}
 		}
-
-		if options.NewIndexSchema && (options.Filter.MaxSchemaVersion != "" || options.Filter.MinSchemaVersion != "") {
-			if options.Filter.MinSchemaVersion != "" {
-				q.Add("minSchemaVersion", options.Filter.MinSchemaVersion)
+		if options.NewIndexSchema {
+			if options.Filter.MaxSchemaVersion != "" || options.Filter.MinSchemaVersion != "" {
+				if options.Filter.MinSchemaVersion != "" {
+					q.Add("minSchemaVersion", options.Filter.MinSchemaVersion)
+				}
+				if options.Filter.MaxSchemaVersion != "" {
+					q.Add("maxSchemaVersion", options.Filter.MaxSchemaVersion)
+				}
 			}
-			if options.Filter.MaxSchemaVersion != "" {
-				q.Add("maxSchemaVersion", options.Filter.MaxSchemaVersion)
+			if options.Filter.Deprecated == "true" || options.Filter.Deprecated == "false" {
+				q.Add("deprecated", options.Filter.Deprecated)
 			}
 		}
 		urlObj.RawQuery = q.Encode()

--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -48,9 +48,11 @@ const (
 	DevfilePNGLogoMediaType = "image/png"
 	DevfileArchiveMediaType = "application/x-tar"
 
-	OwnersFile                 = "OWNERS"
-	registryLibrary            = "registry-library" //constant to indicate that function is called by the library
-	httpRequestResponseTimeout = 30 * time.Second   // httpRequestTimeout configures timeout of all HTTP requests
+	OwnersFile                                  = "OWNERS"
+	registryLibrary                             = "registry-library" //constant to indicate that function is called by the library
+	httpRequestResponseTimeout                  = 30 * time.Second   // httpRequestTimeout configures timeout of all HTTP requests
+	DeprecatedFilterTrue       DeprecatedFilter = "true"
+	DeprecatedFilterFalse      DeprecatedFilter = "false"
 )
 
 var (
@@ -64,6 +66,9 @@ type Registry struct {
 	registryContents []indexSchema.Schema
 	err              error
 }
+
+// DeprecatedFilter to manage the deprecated filter values
+type DeprecatedFilter string
 
 // TelemetryData structure to pass in client telemetry information
 // The User and Locale fields should be passed in by clients if telemetry opt-in is enabled
@@ -106,7 +111,7 @@ type RegistryFilter struct {
 	// Deprecated is set to filter devfile index for stacks having the "Deprecated" tag inside their default set of tags
 	// or not. the only acceptable values are "true"/"false". in case the value is "true" it will only include only
 	// deprecated stacks, if is "false" only non deprecated. will only be applied if `NewIndexSchema=true`
-	Deprecated string
+	Deprecated DeprecatedFilter
 }
 
 // GetRegistryIndex returns the list of index schema structured stacks and/or samples from a specified devfile registry.
@@ -165,7 +170,7 @@ func GetRegistryIndex(registryURL string, options RegistryOptions, devfileTypes 
 					q.Add("maxSchemaVersion", options.Filter.MaxSchemaVersion)
 				}
 			}
-			if options.Filter.Deprecated == "true" || options.Filter.Deprecated == "false" {
+			if options.Filter.Deprecated == DeprecatedFilterTrue || options.Filter.Deprecated == DeprecatedFilterFalse {
 				q.Add("deprecated", options.Filter.Deprecated)
 			}
 		}

--- a/registry-library/library/library.go
+++ b/registry-library/library/library.go
@@ -171,7 +171,7 @@ func GetRegistryIndex(registryURL string, options RegistryOptions, devfileTypes 
 				}
 			}
 			if options.Filter.Deprecated == DeprecatedFilterTrue || options.Filter.Deprecated == DeprecatedFilterFalse {
-				q.Add("deprecated", options.Filter.Deprecated)
+				q.Add("deprecated", string(options.Filter.Deprecated))
 			}
 		}
 		urlObj.RawQuery = q.Encode()

--- a/registry-library/library/library_test.go
+++ b/registry-library/library/library_test.go
@@ -338,7 +338,7 @@ func TestGetRegistryIndex(t *testing.T) {
 			options: RegistryOptions{
 				NewIndexSchema: true,
 				Filter: RegistryFilter{
-					Deprecated: "true",
+					Deprecated: DeprecatedFilterTrue,
 				},
 			},
 			devfileTypes: []indexSchema.DevfileType{indexSchema.StackDevfileType},
@@ -350,7 +350,7 @@ func TestGetRegistryIndex(t *testing.T) {
 			options: RegistryOptions{
 				NewIndexSchema: true,
 				Filter: RegistryFilter{
-					Deprecated: "false",
+					Deprecated: DeprecatedFilterFalse,
 				},
 			},
 			devfileTypes: []indexSchema.DevfileType{indexSchema.StackDevfileType},

--- a/registry-library/library/library_test.go
+++ b/registry-library/library/library_test.go
@@ -50,6 +50,19 @@ var (
 		},
 	}
 
+	deprecatedFilteredIndex = []indexSchema.Schema{
+		{
+			Name: "deprecatedindex1",
+			Tags: []string{"Deprecated, arm64"},
+		},
+	}
+
+	nonDeprecatedFilteredIndex = []indexSchema.Schema{
+		{
+			Name: "deprecatedindex2",
+		},
+	}
+
 	schemaVersionFilteredIndex = []indexSchema.Schema{
 		{
 			Name: "indexSchema2.1",
@@ -206,6 +219,10 @@ func setUpIndexHandle(indexUrl *url.URL) []indexSchema.Schema {
 
 	if strings.Contains(indexUrl.String(), "arch=amd64&arch=arm64") {
 		data = archFilteredIndex
+	} else if strings.Contains(indexUrl.String(), "deprecated=true") {
+		data = deprecatedFilteredIndex
+	} else if strings.Contains(indexUrl.String(), "deprecated=false") {
+		data = nonDeprecatedFilteredIndex
 	} else if strings.Contains(indexUrl.String(), "maxSchemaVersion=2.2") && strings.Contains(indexUrl.String(), "minSchemaVersion=2.1") {
 		data = schemaVersionFilteredIndex
 	} else if indexUrl.Path == "/index/sample" {
@@ -314,6 +331,30 @@ func TestGetRegistryIndex(t *testing.T) {
 			},
 			devfileTypes: []indexSchema.DevfileType{indexSchema.StackDevfileType},
 			wantSchemas:  schemaVersionFilteredIndex,
+		},
+		{
+			name: "Get Deprecated Filtered Index",
+			url:  "http://" + serverIP,
+			options: RegistryOptions{
+				NewIndexSchema: true,
+				Filter: RegistryFilter{
+					Deprecated: "true",
+				},
+			},
+			devfileTypes: []indexSchema.DevfileType{indexSchema.StackDevfileType},
+			wantSchemas:  deprecatedFilteredIndex,
+		},
+		{
+			name: "Get Non Deprecated Filtered Index",
+			url:  "http://" + serverIP,
+			options: RegistryOptions{
+				NewIndexSchema: true,
+				Filter: RegistryFilter{
+					Deprecated: "false",
+				},
+			},
+			devfileTypes: []indexSchema.DevfileType{indexSchema.StackDevfileType},
+			wantSchemas:  nonDeprecatedFilteredIndex,
 		},
 		{
 			name: "Get Arch Filtered Index",


### PR DESCRIPTION
**Please specify the area for this PR**

/area registry-library

**What does does this PR do / why we need it**:

After the implementation for https://github.com/api/issues/959 we have now the ability of filtering the registry index for deprecated or non deprecated stacks by adding a `deprecated=true/false` parameter in the URL.

This PR updates the `registry-library` importing the same logic followed to the index server too.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/1065

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
