### PR TITLE
Fix build and push scripts to allow Podman alias

### DIFF
--- a/build_registry.sh
+++ b/build_registry.sh
@@ -18,7 +18,6 @@
 # This script builds a devfile registry index container image based on the mock devfile registry data under tests/registry
 # This can be useful if developing components within this repository (such as the index server or build tools)
 # and want to test all of the components together
-shopt -s expand_aliases
 set -ex
 
 # Set base registry support directory

--- a/index/server/README.md
+++ b/index/server/README.md
@@ -37,6 +37,7 @@ paths:
 See [swagger.io/docs](https://swagger.io/docs/specification/paths-and-operations) for more information.
 
 ## Build
+To run the build scripts with `Podman` instead of `Docker` first run `export USE_PODMAN=true`.
 
 The registry index server is built into a container image, `devfile-index-base:latest`, by running the following script:
 

--- a/index/server/build.sh
+++ b/index/server/build.sh
@@ -15,6 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# this script is commonly called from build_registry.sh and the podman alias is passed down from that script
+# this can also affect pathing, to combat this we only run the setenv.sh script if build.sh is being run solo
+if [ "$0" == "$BASH_SOURCE" ]; then
+    . ../../setenv.sh
+fi
+
 # Build the index container for the registry
 buildfolder="$(realpath $(dirname ${BASH_SOURCE[0]}))"
 

--- a/index/server/push.sh
+++ b/index/server/push.sh
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# set podman alias if necessary
+. ../../setenv.sh
+
 IMAGE_TAG=$1
 docker tag devfile-index-base:latest $IMAGE_TAG
 docker push $IMAGE_TAG

--- a/setenv.sh
+++ b/setenv.sh
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 # This script aliases the docker cli if the environment variable USE_PODMAN is set to true.
+shopt -s expand_aliases
 
 # default value is false if USE_PODMAN is unset or null
 podman=${USE_PODMAN:-false}

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -8,9 +8,13 @@ If you want to run the build scripts with Podman, set the environment variable
 
 The integration tests can be built to either run in a Docker container, or locally on your machine.
 
-To build the test docker image, run `./docker-build.sh`
+### Container Based
+To build the test container image, run `./docker-build.sh`.
 
-To build the test binary locally, run: `./build.sh`
+To tag and push the test container image to a repository of your choice, run `./docker-push.sh <your-image-tag>`. By default the tag will be `localhost/devfile-registry-integration:latest`.
+
+### Local
+To build the test binary locally, run: `./build.sh`.
 
 ## Custom Tests
 


### PR DESCRIPTION
**Please specify the area for this PR**
Build scripts and documentation

**What does does this PR do / why we need it**:
This PR fixes an issue where running `docker-build.sh` and `docker-push.sh` from `test/integration` was not properly setting the Podman alias. This was due to `setenv.sh` not being able to expand its set alias back into the calling scripts environment. This was fixed with the addition of `shopt -s expand_aliases` to `setenv.sh`.

Additionally, when you run `docker-push.sh` it is looking for a command-line argument for the tag and that was not documented anywhere so I added a snippet for that to `README.md`.

This PR also removes `shopt -s expand_aliases` from `build_registry.sh` as it is no longer required. This is due to the alias expansion happening in the `setenv.sh` script.

The index/server `build.sh` and `push.sh` scripts were also updated to properly use Podman when `USE_PODMAN` is set to `true`.

**Which issue(s) this PR fixes**:

fixes https://github.com/devfile/api/issues/1502
fixes https://github.com/devfile/api/issues/1426

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
1. Run `export USE_PODMAN=true`
2. cd into `tests/integration`
3. Run `./docker-build.sh` and/or `./docker-push.sh <tag>`
4. cd into `index/server`
5. Run `./build.sh` and/or `./push.sh <tag>`
6. From root run `bash build_registry.sh`