### PR TITLE
Spike/complete podman support

### DIFF
--- a/oci-registry/README.md
+++ b/oci-registry/README.md
@@ -3,8 +3,11 @@
 This folder contains the Dockerfile for the OCI registry server. It is based off of the [reference implementation from Docker](https://github.com/docker/distribution), but using a UBI-8 base image rather than Alpine.
 
 ## Build
+The scripts in this project support both `Docker` and `Podman` container engines. By default the scripts will run using `Docker`, to use `Podman` first run `export USE_PODMAN=true`.
 
-To build the image, run `build.sh`.
+To build the image, run `bash build.sh`.
+
+To push the image to a repository of your choice, you can run `bash push.sh <repository-tag>`.
 
 ## Deploy
 

--- a/oci-registry/build.sh
+++ b/oci-registry/build.sh
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# set podman alias if necessary
+. ../setenv.sh
+
 # Build the index container for the registry
 buildfolder="$(basename "$(dirname "$0")")"
 docker build -t oci-registry:next $buildfolder

--- a/oci-registry/build.sh
+++ b/oci-registry/build.sh
@@ -15,9 +15,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# set podman alias if necessary
-. ../setenv.sh
-
 # Build the index container for the registry
 buildfolder="$(basename "$(dirname "$0")")"
+
+# set podman alias if necessary
+. ${buildfolder}/../setenv.sh
+
 docker build -t oci-registry:next $buildfolder

--- a/oci-registry/push.sh
+++ b/oci-registry/push.sh
@@ -15,6 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# set podman alias if necessary
+. ../setenv.sh
+
 IMAGE_TAG=$1
 docker tag oci-registry:next $IMAGE_TAG
 docker push $IMAGE_TAG

--- a/oci-registry/push.sh
+++ b/oci-registry/push.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # set podman alias if necessary
-. ../setenv.sh
+. $(basename "$(dirname "$0")")/../setenv.sh
 
 IMAGE_TAG=$1
 docker tag oci-registry:next $IMAGE_TAG


### PR DESCRIPTION
**Please specify the area for this PR**
Build scripts

**What does does this PR do / why we need it**:
Enables `podman` to be used as a container engine for the build scripts in `/oci-registry`.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/1503

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
1. cd `oci-registry`
2. Run `export USE_PODMAN=true`
3. Run `bash build.sh` and/or `bash push.sh <repository-tag>` 