### PR TITLE
Helm Chart OpenShift Route Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,49 +52,7 @@ See the following for more on the component specific build process:
 We recommend using the [Devfile Registry Operator](https://github.com/devfile/registry-operator) to install a Devfile Registry on your Kubernetes or OpenShift cluster. Consult [its Readme for more information](https://github.com/devfile/registry-operator#running-the-controller-in-a-cluster).
 
 ### Via the Devfile Registry Helm Chart
-
-Alternatively, a Helm chart is also provided if you do not wish to use an operator. To install (with Helm 3) run:
-
-```bash
-$ helm install devfile-registry ./deploy/chart/devfile-registry \ 
-    --set global.ingress.domain=<ingress-domain> \
-	--set devfileIndex.image=<index-image> \
-	--set devfileIndex.tag=<index-image-tag>
-```
-
-Where `<ingress-domain>` is the ingress domain for your cluster, `<index-image>` is the devfile index image you want to deploy, and `<index-image-tag>` is the corresponding image tag for the devfile index image.
-
-For example, if you're installing your own custom devfile registry image for dev/test purposes on Minikube, you might run:
-
-```bash
-$ helm install devfile-registry ./deploy/chart/devfile-registry \
-    --set global.ingress.domain="$(minikube ip).nip.io" \
-	--set devfileIndex.image=quay.io/someuser/devfile-index \
-	--set devfileIndex.tag=latest
-```
-
-You can deploy a devfile registry with a custom registry viewer image (uses `quay.io/devfile/registry-viewer:next` by default) by running the following:
-
-```bash
-$ helm install devfile-registry ./deploy/chart/devfile-registry \
-    --set global.ingress.domain="$(minikube ip).nip.io" \
-	--set devfileIndex.image=quay.io/someuser/devfile-index \
-	--set devfileIndex.tag=latest \
-	--set registryViewer.image=quay.io/someuser/registry-viewer \
-	--set registryViewer.tag=latest
-```
-
-You can deploy a *headless* devfile registry (i.e. without the registry viewer) by specifying `--set global.headless=true` which will look like:
-
-```bash
-$ helm install devfile-registry ./deploy/chart/devfile-registry \
-    --set global.ingress.domain="$(minikube ip).nip.io" \
-	--set global.headless=true \
-	--set devfileIndex.image=quay.io/someuser/devfile-index \
-	--set devfileIndex.tag=latest
-```
-
-For more information on the Helm chart, consult [its readme](deploy/chart/devfile-registry/README.md).
+Alternatively, a Helm chart is also provided if you do not wish to use an operator. You can find instructions below for installing via Helm to either a Kubernetes or OpenShift environment. You can find detailed instructions [here](deploy/chart/devfile-registry/README.md).
 
 ## Contributing
 

--- a/deploy/chart/devfile-registry/README.md
+++ b/deploy/chart/devfile-registry/README.md
@@ -21,17 +21,84 @@ E.g. if your cluster's ingress domain is 192.168.1.0.nip.io, you would run:
 helm install devfile-registry deploy/chart/devfile-registry --set global.ingress.domain=192.168.1.0.nip.io
 ```
 
+### Kubernetes Installation Examples
+```bash
+$ helm install devfile-registry ./deploy/chart/devfile-registry \ 
+    --set global.ingress.domain=<ingress-domain> \
+	--set devfileIndex.image=<index-image> \
+	--set devfileIndex.tag=<index-image-tag>
+```
+
+Where `<ingress-domain>` is the ingress domain for your cluster, `<index-image>` is the devfile index image you want to deploy, and `<index-image-tag>` is the corresponding image tag for the devfile index image.
+
+For example, if you're installing your own custom devfile registry image for dev/test purposes on Minikube, you might run:
+
+```bash
+$ helm install devfile-registry ./deploy/chart/devfile-registry \
+    --set global.ingress.domain="$(minikube ip).nip.io" \
+	--set devfileIndex.image=quay.io/someuser/devfile-index \
+	--set devfileIndex.tag=latest
+```
+
+You can deploy a devfile registry with a custom registry viewer image (uses `quay.io/devfile/registry-viewer:next` by default) by running the following:
+
+```bash
+$ helm install devfile-registry ./deploy/chart/devfile-registry \
+    --set global.ingress.domain="$(minikube ip).nip.io" \
+	--set devfileIndex.image=quay.io/someuser/devfile-index \
+	--set devfileIndex.tag=latest \
+	--set registryViewer.image=quay.io/someuser/registry-viewer \
+	--set registryViewer.tag=latest
+```
+
+You can deploy a *headless* devfile registry (i.e. without the registry viewer) by specifying `--set global.headless=true` which will look like:
+
+```bash
+$ helm install devfile-registry ./deploy/chart/devfile-registry \
+    --set global.ingress.domain="$(minikube ip).nip.io" \
+	--set global.headless=true \
+	--set devfileIndex.image=quay.io/someuser/devfile-index \
+	--set devfileIndex.tag=latest
+```
+
 ## Installing the Devfile Registry on OpenShift
 
-If you're installing on OpenShift, you need to set `global.isOpenShift` to true, for example:
+If you're installing on OpenShift, you will first need to set `global.isOpenShift` to true, for example:
 ```
 helm install devfile-registry deploy/chart/devfile-registry --set global.isOpenShift=true
 ```
 
-or, if you want to install a specific devfile index image, you can run:
+There are 3 ways that you can install the registry on OpenShift:
+#### 1: Via Installation Script With OpenShift Generated Route Hostname and Domain
+
+If you wish to take advantage of OpenShift's generated hostname and domain, all you need to run is:
 ```
-helm install devfile-registry deploy/chart/devfile-registry --set global.isOpenShift=true --set devfileIndex.image=quay.io/myuser/devfile-index --set devfileIndex.tag=latest
+$ bash ./helm-openshift-install.sh
 ```
+This will install the Devfile Registry to OpenShift for you with the generated route hostname and domain. If you wish to include additional arguments such as changing the image for `devfileIndex`, you can include those alongside the script call:
+```
+$ bash ./helm-openshift-install.sh \
+--set devfileIndex.image=quay.io/someuser/devfile-index \
+--set devfileIndex.tag=latest
+```
+#### 2: Via Installation Script With Custom Hostname
+
+Similar to the above instructions, you can set your own custom domain as part of the arguments to the installation script.
+```
+$ bash ./helm-openshift-install.sh --set global.route.domain=<domain> <other arguments>
+```
+
+#### 3: Via Helm CLI With Custom Hostname
+
+If you do not wish to use a helper script to install to OpenShift, you are able to mimic the Kubernetes installation with one slight change. Instead of `--set global.ingress.domain` you will swap it with `--set global.route.domain` as OpenShift utilizes Routes instead of Ingress.
+```bash
+$ helm install devfile-registry ./deploy/chart/devfile-registry \ 
+    --set global.route.domain=<route-domain> \
+	--set devfileIndex.image=<index-image> \
+	--set devfileIndex.tag=<index-image-tag>
+```
+
+Installing to OpenShift follows the same process as Kubernetes, you just need to ensure that `--set global.isOpenShift=true` is an argument to the install. Additionally, instead of `--set global.ingress.domain=<domain>` for Kubernetes you will instead include `--set global.route.domain=<domain>` for OpenShift. All other arguments are available to either Kubernetes or OpenShift.
 
 ## Updating the Devfile Registry
 
@@ -62,8 +129,9 @@ The following fields can be configured in the Helm chart, either via the `values
 
 | Parameter                              | Description                                     | Default                                                    |
 | -----------------------                | ---------------------------------------------   | ---------------------------------------------------------- |
-| `global.ingress.domain`                | Ingress domain for the devfile registry                                        | **MUST BE SET BY USER**     |
+| `global.ingress.domain`                | Kubernetes Ingress domain for the devfile registry                                        | **MUST BE SET BY USER**     |
 | `global.ingress.class`                 | Ingress class for the devfile registry                                         | `nginx` |
+| `global.route.domain`                  | OpenShift Route domain for the devfile registry                                          | **MUST BE SET BY USER**    |
 | `global.ingress.secretName`            | Name of an existing tls secret if using TLS                                    | ` '' ` |
 | `global.isOpenShift  `                 | Set to true to use OpenShift routes instead of ingress                         | `false` |
 | `global.tlsEnabled`                    | Set to true to use the devfile registry with TLS                               | `false` |

--- a/deploy/chart/devfile-registry/README.md
+++ b/deploy/chart/devfile-registry/README.md
@@ -63,12 +63,15 @@ $ helm install devfile-registry ./deploy/chart/devfile-registry \
 
 ## Installing the Devfile Registry on OpenShift
 
-If you're installing on OpenShift, you will first need to set `global.isOpenShift` to true, for example:
+If you're installing on OpenShift, you need to set `global.isOpenShift` to true, for example:
 ```
 helm install devfile-registry deploy/chart/devfile-registry --set global.isOpenShift=true
 ```
+#### Installation Via Helper Script Environment Variables
+By default the name of the install will be `devfile-registry` and the path to the chart will be `/deploy/chart/devfile-registry` as `helm-openshift-install.sh` is located at the root of the repository. If you wish to change these values you need to set the `INSTALL_NAME` and `CHART_PATH` environment variables prior to running the script. Note that `devfile-registry` will be postfixed to any custom name, e.g. `export $INSTALL_NAME=my-install` will result in a Helm install for `my-install-devfile-registry`.
 
-There are 3 ways that you can install the registry on OpenShift:
+
+There are 4 ways that you can install the registry on OpenShift:
 #### 1: Via Installation Script With OpenShift Generated Route Hostname and Domain
 
 If you wish to take advantage of OpenShift's generated hostname and domain, all you need to run is:
@@ -81,6 +84,7 @@ $ bash ./helm-openshift-install.sh \
 --set devfileIndex.image=quay.io/someuser/devfile-index \
 --set devfileIndex.tag=latest
 ```
+
 #### 2: Via Installation Script With Custom Hostname
 
 Similar to the above instructions, you can set your own custom domain as part of the arguments to the installation script.
@@ -99,6 +103,13 @@ $ helm install devfile-registry ./deploy/chart/devfile-registry \
 ```
 
 Installing to OpenShift follows the same process as Kubernetes, you just need to ensure that `--set global.isOpenShift=true` is an argument to the install. Additionally, instead of `--set global.ingress.domain=<domain>` for Kubernetes you will instead include `--set global.route.domain=<domain>` for OpenShift. All other arguments are available to either Kubernetes or OpenShift.
+
+#### 4: Via Helm CLI With OpenShift Generated Route Hostname and Domain
+If you wish to manually mimic the `helm-openshift-install.sh` helper script you can follow these steps:
+1. Run `helm install <name> <chart path> --set global.isOpenShift=true <more arguments>`
+2. Wait for the initial deployment to finish
+3. Run `oc get route <name> -o jsonpath='{.spec.host}'` to obtain the generated route
+4. Run `helm upgrade <name> <chart path> --reuse-values --set global.route.domain=<route from step 3>`
 
 ## Updating the Devfile Registry
 

--- a/deploy/chart/devfile-registry/templates/_template.tpl
+++ b/deploy/chart/devfile-registry/templates/_template.tpl
@@ -22,12 +22,38 @@
 {{- .Values.global.ingress.domain | printf "%s.%s" $hostname -}}
 {{- end -}}
 
+{{- define "devfileregistry.routeHostname" -}}
+{{- $hostname := .Values.hostnameOverride | default (printf "devfile-registry-%s" .Release.Namespace) -}}
+{{- if eq .Values.global.route.domain "" -}} # This allows for Openshift to generate the route name + domain
+{{- .Values.global.route.domain -}}
+{{- else -}}
+{{- .Values.global.route.domain | printf "%s.%s" $hostname -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "devfileregistry.ingressUrl" -}}
 {{- $hostname := .Values.hostnameOverride | default (printf "devfile-registry-%s" .Release.Namespace) -}}
 {{- if .Values.global.tlsEnabled -}}
 {{- .Values.global.ingress.domain | printf "https://%s.%s" $hostname -}}
 {{- else -}}
 {{- .Values.global.ingress.domain | printf "http://%s.%s" $hostname -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "devfileregistry.routeUrl" -}}
+{{- $hostname := .Values.hostnameOverride | default (printf "devfile-registry-%s" .Release.Namespace) -}}
+{{- if .Values.global.tlsEnabled -}}
+{{- .Values.global.route.domain | printf "https://%s.%s" $hostname -}}
+{{- else -}}
+{{- .Values.global.route.domain | printf "http://%s.%s" $hostname -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "devfileregistry.fqdnUrl" -}}
+{{- if .Values.global.isOpenShift -}}
+{{- template "devfileregistry.routeUrl" . -}}
+{{- else -}}
+{{- template "devfileregistry.ingressUrl" . -}}
 {{- end -}}
 {{- end -}}
 

--- a/deploy/chart/devfile-registry/templates/deployment.yaml
+++ b/deploy/chart/devfile-registry/templates/deployment.yaml
@@ -146,7 +146,7 @@ spec:
                 {
                   "name": "{{ template "devfileregistry.name" . }}",
                   "url": "http://localhost:8080",
-                  "fqdn": "{{ template "devfileregistry.ingressUrl" . }}"
+                  "fqdn": "{{ template "devfileregistry.fqdnUrl" . }}"
                 }
               ]
         securityContext:

--- a/deploy/chart/devfile-registry/templates/route.yaml
+++ b/deploy/chart/devfile-registry/templates/route.yaml
@@ -21,6 +21,7 @@ metadata:
   name: {{ template "devfileregistry.fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
+  host: {{ template "devfileregistry.routeHostname" . }}
   to:
     kind: Service
     name: {{ template "devfileregistry.fullname" . }}

--- a/deploy/chart/devfile-registry/values.yaml
+++ b/deploy/chart/devfile-registry/values.yaml
@@ -18,6 +18,8 @@ global:
     class: 'nginx'
     domain: 192.168.2.1.nip.io
     secretName: ''
+  route: 
+    domain: ""
   isOpenShift: false
   tlsEnabled: false
   headless: false

--- a/helm-openshift-install.sh
+++ b/helm-openshift-install.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+#
+# Copyright Red Hat
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 <arguments>"
+    exit 1
+fi
+
+START_TIME=$(date +%s)
+TIMEOUT_SEC=25 
+SPINUP_SEC=60 # Helm Upgrade can have unexpected results if it is run while the cluster is initially starting
+
+# Run the install without the generated Openshift Route being passed to Registry Viewer fqdn as it does not exist yet
+helm install devfile-registry deploy/chart/devfile-registry --set global.isOpenShift=true "$@"
+
+while true; do
+    ROUTE=$(oc get route devfile-registry -o jsonpath='{.spec.host}' 2>/dev/null)
+    if [ -n "$ROUTE" ]; then
+        echo Domain found: "$ROUTE"
+        break
+    fi
+    new_time=$(date +%s)
+    elapsed_time=$((new_time - START_TIME))
+    if [ $elapsed_time -ge $TIMEOUT_SEC ]; then
+        echo "TIMEOUT: Domain not found."
+        exit 1
+    fi
+    sleep 1
+done
+
+# Allow deployment to start occuring before the upgrade
+sleep $SPINUP_SEC
+
+# Run upgrade with the new variable to set fqdn of the Registry Viewer
+helm upgrade devfile-registry deploy/chart/devfile-registry --reuse-values --set global.route.domain=$ROUTE 


### PR DESCRIPTION
**Please specify the area for this PR**
Bug fix and small enhancement

**What does does this PR do / why we need it**:
This PR aims to address the issue that occurs when a user installs the `devfile registry` via Helm to an OpenShift environment. Prior to this change the `fqdn` of the `registry-viewer` was not properly being set as it was expecting `global.ingress.domain` to be set, but if you are installing to OpenShift it was not a requirement to set that.

In order to solve this problem the following was added:
1. A helper script for OpenShift installations via Helm
   - This script allows a user to have the `fqdn` properly set if OpenShift auto generates a domain for you, or if you set a domain yourself. It utilizes `Helm Upgrade` to mimic the functionality currently in place for the `registry operator` where the `fqdn` is set after deployment (it spins up a new replacement pod after the information is known).

2. Template updates
   - In order to have more clarity and consistency, the template used by Helm now has portions for both `OpenShift Routes` and `Kubernetes Ingresses`.

3. Updated documentation
   - As a result of changes, documentation was updated to accurately reflect the different ways you can install the `devfile registry` with the use of a Helm chart.

**Which issue(s) this PR fixes**:

Fixes https://github.com/devfile/api/issues/1467

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
The following cases will result in the `fqdn` of the `registry-viewer` being properly set:
1. Install to OpenShift with the use of the new script WITH & WITHOUT setting a domain
2. Install to OpenShift using the Helm CLI WITHOUT setting a domain
3. Install to Kubernetes using the Helm CLI WITH & WITHOUT setting a domain

The following case will result in the `fqdn` not being properly set:
1. Install to OpenShift with the Helm CLI WITH setting a domain