### PR TITLE
Allow samples cache directory to be created if non-existent

### DIFF
--- a/build-tools/cache_samples.sh
+++ b/build-tools/cache_samples.sh
@@ -99,7 +99,7 @@ function cache_devfile() {
     fi
 }
 
-if [[ "$OSTYPE" == "darwin" ]]
+if [[ "$OSTYPE" == "darwin"* ]]
 then
   if [[ $1 != ./* ]] && [[ $1 != ../* ]] && [[ $1 != /* ]]
   then

--- a/build-tools/cache_samples.sh
+++ b/build-tools/cache_samples.sh
@@ -103,7 +103,7 @@ devfileEntriesFile=$1
 samplesDir=$2
 
 for sample in $(yq e '(.samples[].name)' $devfileEntriesFile); do
-  mkdir $samplesDir/$sample
+  mkdir -p $samplesDir/$sample
   echo $sample
   cache_sample $sample $samplesDir/$sample
 done

--- a/build-tools/cache_samples.sh
+++ b/build-tools/cache_samples.sh
@@ -99,8 +99,24 @@ function cache_devfile() {
     fi
 }
 
-devfileEntriesFile=$1
-samplesDir=$2
+if [[ "$OSTYPE" == "darwin" ]]
+then
+  if [[ $1 != ./* ]] && [[ $1 != ../* ]] && [[ $1 != /* ]]
+  then
+    devfileEntriesFile=./$1
+  else
+    devfileEntriesFile=$1
+  fi
+  if [[ $2 != ./* ]] && [[ $2 != ../* ]] && [[ $2 != /* ]]
+  then
+    samplesDir=./$2
+  else
+    samplesDir=$2
+  fi
+else
+  devfileEntriesFile=$1
+  samplesDir=$2
+fi
 
 for sample in $(yq e '(.samples[].name)' $devfileEntriesFile); do
   mkdir -p $samplesDir/$sample


### PR DESCRIPTION
**Please specify the area for this PR**

build-tools

**What does does this PR do / why we need it**:

Changes `mkdir $samplesDir/$sample` to `mkdir -p $samplesDir/$sample` to allow target cache directories which do not exist yet.

**Which issue(s) this PR fixes**:

Fixes #?

fixes devfile/api#1553

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:

Run `bash build-tools/cache_samples.sh extraDevfileEntries.yaml <non_existent_caching_path>`
