### PR TITLE
Bump yq to use `v4.44.1`

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -18,7 +18,8 @@ FROM golang:1.19-alpine@sha256:276692412aea6f9dd6cdc5725b2f1c05bef8df7223811afbc
 RUN apk add --no-cache git bash curl zip
 
 # Install yq
-RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/v4.9.5/yq_linux_amd64 -o /usr/local/bin/yq && mv ./yq_linux_amd64 /usr/local/bin/yq && chmod +x /usr/local/bin/yq
+ENV YQ_VERSION=v4.44.1
+RUN curl -sL -O https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -o /usr/local/bin/yq && mv ./yq_linux_amd64 /usr/local/bin/yq && chmod +x /usr/local/bin/yq
 RUN yq
 
 # Copy the registry build tools

--- a/build-tools/cache_samples.sh
+++ b/build-tools/cache_samples.sh
@@ -47,12 +47,12 @@ function cache_sample() {
     sampleDir=$tempDir/$sampleName
 
     # Git clone the sample project
-    gitRepository="$(yq e '(.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.git.remotes.origin)' -)"
-    revision="$(yq e '(.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.git.revision)' -)"
+    gitRepository="$(yq e '.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.git.remotes.origin)' -)"
+    revision="$(yq e '.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.git.revision)' -)"
     if [[ $gitRepository == "null" ]]; then
-        for version in $(yq e '(.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.versions[].version)' -); do
-          gitRepository="$(yq e '(.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.versions[] | select(.version == "'${version}'")' -| yq e '.git.remotes.origin' -)"
-          revision="$(yq e '(.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.versions[] | select(.version == "'${version}'")' -| yq e '.git.revision' -)"
+        for version in $(yq e '.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.versions[].version)' -); do
+          gitRepository="$(yq e '.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '.versions[] | select(.version == "'${version}'")' -| yq e '.git.remotes.origin' -)"
+          revision="$(yq e '.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '.versions[] | select(.version == "'${version}'")' -| yq e '.git.revision' -)"
           clone_sample_repo $gitRepository $sampleDir/$version $revision
           mkdir $outputDir/$version
           cache_devfile $sampleDir/$version $outputDir/$version $sampleName
@@ -63,7 +63,7 @@ function cache_sample() {
     fi
 
     # Cache the icon for the sample
-    local iconPath="$(yq e '(.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.icon)' -)"
+    local iconPath="$(yq e '.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '(.icon)' -)"
     if [[ $iconPath != "null" ]]; then
       urlRegex='(https?)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
       if [[ $iconPath =~ $urlRegex ]]; then

--- a/build-tools/cache_samples.sh
+++ b/build-tools/cache_samples.sh
@@ -54,7 +54,9 @@ function cache_sample() {
           gitRepository="$(yq e '.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '.versions[] | select(.version == "'${version}'")' -| yq e '.git.remotes.origin' -)"
           revision="$(yq e '.samples[] | select(.name == "'${sampleName}'")' $devfileEntriesFile | yq e '.versions[] | select(.version == "'${version}'")' -| yq e '.git.revision' -)"
           clone_sample_repo $gitRepository $sampleDir/$version $revision
-          mkdir $outputDir/$version
+          if [ ! -d $outputDir/$version ]; then
+            mkdir $outputDir/$version
+          fi
           cache_devfile $sampleDir/$version $outputDir/$version $sampleName
         done
     else

--- a/build-tools/dl_starter_projects.sh
+++ b/build-tools/dl_starter_projects.sh
@@ -16,7 +16,7 @@
 # limitations under the License.
 
 # Path of stacks directory in the registry
-STACKS_DIR=/registry/stacks
+STACKS_DIR=${STACKS_DIR:-/registry/stacks}
 # List of starter projects to use offline
 offline_starter_projects=( "$@" )
 # When no starter projects are specifed,


### PR DESCRIPTION
**Please specify the area for this PR**

build-tools

**What does does this PR do / why we need it**:

Bumps yq to `v4.44.1` to fix issues found in older v4 versions of yq. 

Changes also include:
- Changes needed to work with `yq v4.44.1`
- `build-tools/dl_starter_projects.sh` now lets you override `STACKS_DIR`
- Fixes problem where if a cached sample directory exists `build-tools/cache_samples.sh` breaks, resolved by skipping directory creation if exists, related to devfile/api#1553

**Which issue(s) this PR fixes**:

Fixes #?

related devfile/api#1142

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:

Run `bash build-tools/cache_samples.sh tests/registry/extraDevfileEntries.yaml .cache/samples`

> Fixes problem where if a cached sample directory exists `build-tools/cache_samples.sh` breaks, resolved by skipping directory creation if exists, related to devfile/api#1553

Run `STACKS_DIR=tests/registry/stacks bash build-tools/dl_starter_projects.sh`
