### PR TITLE
bump golang 1.19 image to latest sha

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.19-alpine@sha256:276692412aea6f9dd6cdc5725b2f1c05bef8df7223811afbc6aa16294e2903f9 AS builder
+FROM golang:1.19-alpine@sha256:0ec0646e208ea58e5d29e558e39f2e59fccf39b7bda306cb53bbaff91919eca5 AS builder
 
 # Install dependencies
 RUN apk add --no-cache git bash curl zip

--- a/index/server/Dockerfile
+++ b/index/server/Dockerfile
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Index Server build stage
-FROM golang:1.19-alpine@sha256:276692412aea6f9dd6cdc5725b2f1c05bef8df7223811afbc6aa16294e2903f9 AS index-builder
+FROM golang:1.19-alpine@sha256:0ec0646e208ea58e5d29e558e39f2e59fccf39b7bda306cb53bbaff91919eca5 AS index-builder
 WORKDIR /tools
 COPY . .
 RUN CGO_ENABLED=0 go build -mod=vendor -o index-server main.go

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM golang:1.19-alpine@sha256:276692412aea6f9dd6cdc5725b2f1c05bef8df7223811afbc6aa16294e2903f9
+FROM golang:1.19-alpine@sha256:0ec0646e208ea58e5d29e558e39f2e59fccf39b7bda306cb53bbaff91919eca5
 
 WORKDIR /registry-test
 


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
This PR updates the sha pinned to the golang 1.19 base image, the new version allows for the pulling of different architectures when `--platform` is set. Previously if you tried to build for an architecture that was not `linux/amd64` it would give you a warning about the base image. This is the first of many PRs for https://github.com/devfile/api/issues/1547

**Which issue(s) this PR fixes**:

fixes https://github.com/devfile/api/issues/1547

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
