### PR TITLE
WIP: Add lastModified field to generated index file

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -712,7 +712,8 @@ func validateStackInfo(stackInfo schema.Schema, stackfolderDir string) []error {
 // SetLastModifiedValue adds the last modified value to a pre-created index
 // The last modified dates are contained in a file named last_modified.json that is apart of the registry dir
 func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]schema.Schema, error) {
-	bytes, err := os.ReadFile(registryDirPath + "/last_modified.json")
+	lastModFile := path.Join(registryDirPath, "last_modified.json")
+	bytes, err := os.ReadFile(lastModFile)
 	if err != nil {
 		return index, err
 	}
@@ -725,17 +726,17 @@ func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]sche
 
 	lastModifiedEntriesMap := make(map[string]map[string]string)
 
-	for _, entry := range lastModifiedEntries.Stacks {
-		updateLastModifiedMap(lastModifiedEntriesMap, &entry)
+	for idx := range lastModifiedEntries.Stacks {
+		updateLastModifiedMap(lastModifiedEntriesMap, &lastModifiedEntries.Stacks[idx])
 	}
 
-	for _, entry := range lastModifiedEntries.Samples {
-		updateLastModifiedMap(lastModifiedEntriesMap, &entry)
+	for idx := range lastModifiedEntries.Samples {
+		updateLastModifiedMap(lastModifiedEntriesMap, &lastModifiedEntries.Samples[idx])
 	}
 
-	for _, entry := range index {
-		for idx := range entry.Versions {
-			updateSchemaLastModified(&entry, idx, lastModifiedEntriesMap[entry.Name][entry.Versions[idx].Version])
+	for i := range index {
+		for j := range index[i].Versions {
+			updateSchemaLastModified(&index[i], j, lastModifiedEntriesMap[index[i].Name][index[i].Versions[j].Version])
 		}
 	}
 

--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -711,8 +711,9 @@ func validateStackInfo(stackInfo schema.Schema, stackfolderDir string) []error {
 
 // SetLastModifiedValue adds the last modified value to a pre-created index
 // The last modified dates are contained in a file named last_modified.json that is apart of the registry dir
+/* #nosec G304 -- lastModFile is produced from filepath.Join which cleans the input path */
 func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]schema.Schema, error) {
-	lastModFile := path.Join(registryDirPath, "last_modified.json")
+	lastModFile := filepath.Join(registryDirPath, "last_modified.json")
 	bytes, err := os.ReadFile(lastModFile)
 	if err != nil {
 		return index, err

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -16,6 +16,8 @@
 package schema
 
 import (
+	"time"
+
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -264,4 +266,16 @@ type Version struct {
 	DeploymentScopes map[DeploymentScopeKind]bool `yaml:"deploymentScopes,omitempty" json:"deploymentScopes,omitempty"`
 	Resources        []string                     `yaml:"resources,omitempty" json:"resources,omitempty"`
 	StarterProjects  []string                     `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	LastModified     string                       `yaml:"lastModified,omitempty" json:"lastModified,omitempty"`
+}
+
+type LastModifiedEntry struct {
+	Name         string    `yaml:"name,omitempty" json:"name,omitempty"`
+	Version      string    `yaml:"version,omitempty" json:"version,omitempty"`
+	LastModified time.Time `yaml:"lastModified,omitempty" json:"lastModified,omitempty"`
+}
+
+type LastModifiedInfo struct {
+	Stacks  []LastModifiedEntry `yaml:"stacks,omitempty" json:"stacks,omitempty"`
+	Samples []LastModifiedEntry `yaml:"samples,omitempty" json:"samples,omitempty"`
 }

--- a/index/generator/tests/registry/index_main.json
+++ b/index/generator/tests/registry/index_main.json
@@ -27,7 +27,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2023-04-08"
       },
       {
         "version": "1.1.0",
@@ -47,7 +48,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2023-11-08"
       }
     ]
   },
@@ -80,7 +82,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-13"
       }
     ]
   },
@@ -111,7 +114,8 @@
           "deploy": false,
           "run": true,
           "test": true
-        }
+        },
+        "lastModified": "2024-04-23"
       }
     ]
   },
@@ -144,7 +148,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-04-29"
       }
     ]
   },
@@ -176,7 +181,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-13"
       }
     ]
   },
@@ -228,7 +234,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-13"
       }
     ]
   },
@@ -269,7 +276,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-04-22"
       }
     ]
   },
@@ -318,7 +326,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-27"
       }
     ]
   },
@@ -350,7 +359,8 @@
           "deploy": false,
           "run": true,
           "test": true
-        }
+        },
+        "lastModified": "2024-03-25"
       }
     ]
   },
@@ -382,7 +392,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-28"
       }
     ]
   },
@@ -414,7 +425,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-28"
       }
     ]
   },
@@ -436,7 +448,8 @@
             "origin": "https://github.com/redhat-developer/devfile-sample"
           }
         },
-        "description": "nodejs with devfile v2.0.0"
+        "description": "nodejs with devfile v2.0.0",
+        "lastModified": "2024-06-05"
       },
       {
         "version": "1.0.1",
@@ -447,7 +460,8 @@
             "origin": "https://github.com/nodeshift-starters/devfile-sample"
           }
         },
-        "description": "nodejs with devfile v2.2.0"
+        "description": "nodejs with devfile v2.2.0",
+        "lastModified": "2024-06-05"
       }
     ]
   },
@@ -471,7 +485,8 @@
             "origin": "https://github.com/elsony/devfile-sample-code-with-quarkus.git"
           }
         },
-        "description": "java quarkus with devfile v2.0.0"
+        "description": "java quarkus with devfile v2.0.0",
+        "lastModified": "2024-04-19"
       }
     ]
   }

--- a/index/generator/tests/registry/last_modified.json
+++ b/index/generator/tests/registry/last_modified.json
@@ -1,0 +1,81 @@
+{
+  "stacks": [
+    {
+      "name": "go",
+      "version": "1.1.0",
+      "lastModified": "2023-11-08T12:54:08+00:00"
+    },
+    {
+      "name": "go",
+      "version": "1.2.0",
+      "lastModified": "2023-04-08T11:51:08+00:00"
+    },
+    {
+      "name": "java-maven",
+      "version": "1.1.0",
+      "lastModified": "2024-05-13T12:32:02+02:00"
+    },
+    {
+      "name": "java-openliberty",
+      "version": "0.5.0",
+      "lastModified": "2024-04-23T06:20:34-04:00"
+    },
+    {
+      "name": "java-quarkus",
+      "version": "1.1.0",
+      "lastModified": "2024-04-29T17:08:43+03:00"
+    },
+    {
+      "name": "java-springboot",
+      "version": "1.1.0",
+      "lastModified": "2024-05-13T12:32:02+02:00"
+    },
+    {
+      "name": "java-vertx",
+      "version": "1.1.0",
+      "lastModified": "2024-05-13T12:32:02+02:00"
+    },
+    {
+      "name": "java-wildfly-bootable-jar",
+      "version": "1.0.0",
+      "lastModified": "2024-05-27T11:00:03+02:00"
+    },
+    {
+      "name": "java-wildfly",
+      "version": "1.0.0",
+      "lastModified": "2024-04-22T23:00:14+02:00"
+    },
+    {
+      "name": "nodejs",
+      "version": "1.0.0",
+      "lastModified": "2024-03-25T12:16:30-04:00"
+    },
+    {
+      "name": "python-django",
+      "version": "1.0.0",
+      "lastModified": "2024-05-28T17:20:11+02:00"
+    },
+    {
+      "name": "python",
+      "version": "1.0.0",
+      "lastModified": "2024-05-28T17:20:11+02:00"
+    }
+  ],
+  "samples": [
+    {
+      "name": "nodejs-basic",
+      "version": "1.0.0",
+      "lastModified": "2024-06-05T15:26:11-04:00"
+    },
+    {
+      "name": "nodejs-basic",
+      "version": "1.0.1",
+      "lastModified": "2024-06-05T15:26:11-04:00"
+    },
+    {
+      "name": "code-with-quarkus",
+      "version": "1.1.0",
+      "lastModified": "2024-04-19T11:45:48+01:00"
+    }
+  ]
+}


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
This is the first PR aimed at supporting a `lastModified` query parameter for filtering data. The changes made as part of this PR add functionality for reading a `last_modified.json` file that is added to the `registry` directory during build. The goal is to read these values and assign them to their proper stack/sample versions they belong to within the generated `index` file. 

In addition to this functionality I had to do more data manipulation to allow for the proper setting of these values, it is easier to do this in `go` rather than `bash` so it was done here instead of https://github.com/devfile/registry/pull/429.

Additionally, tests were updated to contain the new field so we can ensure it is being added correctly. 

FYI changes still need to be made on the `index/server` side for the actual endpoint, this is just the `index/generator` work for the index file.

**Which issue(s) this PR fixes**:

fixes https://github.com/devfile/api/issues/1327

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
Go tests should pass - The new field was added to the expected index file.