### PR TITLE
Feature: Last Modified Filter Parameter

### DIFF
--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -712,7 +712,8 @@ func validateStackInfo(stackInfo schema.Schema, stackfolderDir string) []error {
 // SetLastModifiedValue adds the last modified value to a pre-created index
 // The last modified dates are contained in a file named last_modified.json that is apart of the registry dir
 func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]schema.Schema, error) {
-	bytes, err := os.ReadFile(registryDirPath + "/last_modified.json")
+	lastModFile := path.Join(registryDirPath, "last_modified.json")
+	bytes, err := os.ReadFile(lastModFile)
 	if err != nil {
 		return index, err
 	}
@@ -725,17 +726,17 @@ func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]sche
 
 	lastModifiedEntriesMap := make(map[string]map[string]string)
 
-	for _, entry := range lastModifiedEntries.Stacks {
-		updateLastModifiedMap(lastModifiedEntriesMap, &entry)
+	for idx := range lastModifiedEntries.Stacks {
+		updateLastModifiedMap(lastModifiedEntriesMap, &lastModifiedEntries.Stacks[idx])
 	}
 
-	for _, entry := range lastModifiedEntries.Samples {
-		updateLastModifiedMap(lastModifiedEntriesMap, &entry)
+	for idx := range lastModifiedEntries.Samples {
+		updateLastModifiedMap(lastModifiedEntriesMap, &lastModifiedEntries.Samples[idx])
 	}
 
-	for _, entry := range index {
-		for idx := range entry.Versions {
-			updateSchemaLastModified(&entry, idx, lastModifiedEntriesMap[entry.Name][entry.Versions[idx].Version])
+	for i := range index {
+		for j := range index[i].Versions {
+			updateSchemaLastModified(&index[i], j, lastModifiedEntriesMap[index[i].Name][index[i].Versions[j].Version])
 		}
 	}
 

--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -711,8 +711,9 @@ func validateStackInfo(stackInfo schema.Schema, stackfolderDir string) []error {
 
 // SetLastModifiedValue adds the last modified value to a pre-created index
 // The last modified dates are contained in a file named last_modified.json that is apart of the registry dir
+/* #nosec G304 -- lastModFile is produced from filepath.Join which cleans the input path */
 func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]schema.Schema, error) {
-	lastModFile := path.Join(registryDirPath, "last_modified.json")
+	lastModFile := filepath.Join(registryDirPath, "last_modified.json")
 	bytes, err := os.ReadFile(lastModFile)
 	if err != nil {
 		return index, err

--- a/index/generator/library/library.go
+++ b/index/generator/library/library.go
@@ -737,7 +737,10 @@ func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]sche
 
 	for i := range index {
 		for j := range index[i].Versions {
-			updateSchemaLastModified(&index[i], j, lastModifiedEntriesMap[index[i].Name][index[i].Versions[j].Version])
+			schemaItem := index[i] // a stack or sample
+			versions := schemaItem.Versions[j]
+			versionNum := versions.Version
+			updateSchemaLastModified(&schemaItem, j, lastModifiedEntriesMap[schemaItem.Name][versionNum])
 		}
 	}
 

--- a/index/generator/library/library_test.go
+++ b/index/generator/library/library_test.go
@@ -850,3 +850,155 @@ func TestCheckForRequiredMetadata(t *testing.T) {
 		}
 	}
 }
+
+func TestSetLastModifiedValue(t *testing.T) {
+	testRegistryDirPath := "../tests/registry"
+	index := []schema.Schema{
+		schema.Schema{
+			Name:        "go",
+			DisplayName: "Go Runtime",
+			Description: "Stack with the latest Go version",
+			Type:        "stack",
+			Tags:        []string{"Go"},
+			Icon:        "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
+			ProjectType: "go",
+			Language:    "go",
+			Provider:    "Red Hat",
+			Versions: []schema.Version{
+				schema.Version{
+					Version:         "1.2.0",
+					SchemaVersion:   "2.1.0",
+					Description:     "Stack with the latest Go version with devfile v2.1.0 schema version",
+					Icon:            "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
+					Tags:            []string{"testtag"},
+					Links:           map[string]string{"self": "devfile-catalog/go:1.2.0"},
+					Resources:       []string{"devfile.yaml"},
+					StarterProjects: []string{"go-starter"},
+					CommandGroups:   map[schema.CommandGroupKind]bool{"build": true, "debug": false, "deploy": false, "run": true, "test": false},
+				},
+				schema.Version{
+					Version:         "1.1.0",
+					SchemaVersion:   "2.0.0",
+					Description:     "Stack with the latest Go version with devfile v2.0.0 schema version",
+					Icon:            "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
+					Tags:            []string{"Go"},
+					Links:           map[string]string{"self": "devfile-catalog/go:1.1.0"},
+					Resources:       []string{"devfile.yaml"},
+					StarterProjects: []string{"go-starter"},
+					CommandGroups:   map[schema.CommandGroupKind]bool{"build": true, "debug": false, "deploy": false, "run": true, "test": false},
+				},
+			},
+		},
+		schema.Schema{
+			Name:        "code-with-quarkus",
+			DisplayName: "Basic Quarkus",
+			Description: "A simple Hello World Java application using Quarkus",
+			Type:        "sample",
+			Tags:        []string{"Java", "Quarkus"},
+			Icon:        "https://raw.githubusercontent.com/elsony/devfile-sample-code-with-quarkus/main/.devfile/icon/quarkus.png",
+			ProjectType: "quarkus",
+			Language:    "java",
+			Provider:    "Red Hat",
+			Versions: []schema.Version{
+				schema.Version{
+					Version:       "1.1.0",
+					SchemaVersion: "2.0.0",
+					Description:   "java quarkus with devfile v2.0.0",
+					Default:       true,
+					Git: &schema.Git{
+						Remotes: map[string]string{"origin": "https://github.com/elsony/devfile-sample-code-with-quarkus.git"},
+					},
+				},
+			},
+		},
+	}
+
+	wantIndex := []schema.Schema{
+		schema.Schema{
+			Name:         "go",
+			DisplayName:  "Go Runtime",
+			Description:  "Stack with the latest Go version",
+			Type:         "stack",
+			Tags:         []string{"Go"},
+			Icon:         "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
+			ProjectType:  "go",
+			Language:     "go",
+			Provider:     "Red Hat",
+			LastModified: "2023-11-08T12:54:08Z",
+			Versions: []schema.Version{
+				schema.Version{
+					Version:         "1.2.0",
+					SchemaVersion:   "2.1.0",
+					Description:     "Stack with the latest Go version with devfile v2.1.0 schema version",
+					Icon:            "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
+					Tags:            []string{"testtag"},
+					Links:           map[string]string{"self": "devfile-catalog/go:1.2.0"},
+					Resources:       []string{"devfile.yaml"},
+					StarterProjects: []string{"go-starter"},
+					CommandGroups:   map[schema.CommandGroupKind]bool{"build": true, "debug": false, "deploy": false, "run": true, "test": false},
+					LastModified:    "2023-04-08T11:51:08Z",
+				},
+				schema.Version{
+					Version:         "1.1.0",
+					SchemaVersion:   "2.0.0",
+					Description:     "Stack with the latest Go version with devfile v2.0.0 schema version",
+					Icon:            "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
+					Tags:            []string{"Go"},
+					Links:           map[string]string{"self": "devfile-catalog/go:1.1.0"},
+					Resources:       []string{"devfile.yaml"},
+					StarterProjects: []string{"go-starter"},
+					CommandGroups:   map[schema.CommandGroupKind]bool{"build": true, "debug": false, "deploy": false, "run": true, "test": false},
+					LastModified:    "2023-11-08T12:54:08Z",
+				},
+			},
+		},
+		schema.Schema{
+			Name:         "code-with-quarkus",
+			DisplayName:  "Basic Quarkus",
+			Description:  "A simple Hello World Java application using Quarkus",
+			Type:         "sample",
+			Tags:         []string{"Java", "Quarkus"},
+			Icon:         "https://raw.githubusercontent.com/elsony/devfile-sample-code-with-quarkus/main/.devfile/icon/quarkus.png",
+			ProjectType:  "quarkus",
+			Language:     "java",
+			Provider:     "Red Hat",
+			LastModified: "2024-04-19T11:45:48+01:00",
+			Versions: []schema.Version{
+				schema.Version{
+					Version:       "1.1.0",
+					SchemaVersion: "2.0.0",
+					Description:   "java quarkus with devfile v2.0.0",
+					Default:       true,
+					Git: &schema.Git{
+						Remotes: map[string]string{"origin": "https://github.com/elsony/devfile-sample-code-with-quarkus.git"},
+					},
+					LastModified: "2024-04-19T11:45:48+01:00",
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		index     []schema.Schema
+		wantIndex []schema.Schema
+	}{
+		{
+			name:      "Test SetLastModifiedValue",
+			index:     index,
+			wantIndex: wantIndex,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotIndex, err := SetLastModifiedValue(index, testRegistryDirPath)
+			if err != nil {
+				t.Errorf("Failed to set last modified value: %v", err)
+			}
+			if !reflect.DeepEqual(tt.wantIndex, gotIndex) {
+				t.Errorf("Generated index does not match")
+			}
+		})
+	}
+}

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -16,6 +16,8 @@
 package schema
 
 import (
+	"time"
+
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -264,4 +266,16 @@ type Version struct {
 	DeploymentScopes map[DeploymentScopeKind]bool `yaml:"deploymentScopes,omitempty" json:"deploymentScopes,omitempty"`
 	Resources        []string                     `yaml:"resources,omitempty" json:"resources,omitempty"`
 	StarterProjects  []string                     `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	LastModified     string                       `yaml:"lastModified,omitempty" json:"lastModified,omitempty"`
+}
+
+type LastModifiedEntry struct {
+	Name         string    `yaml:"name,omitempty" json:"name,omitempty"`
+	Version      string    `yaml:"version,omitempty" json:"version,omitempty"`
+	LastModified time.Time `yaml:"lastModified,omitempty" json:"lastModified,omitempty"`
+}
+
+type LastModifiedInfo struct {
+	Stacks  []LastModifiedEntry `yaml:"stacks,omitempty" json:"stacks,omitempty"`
+	Samples []LastModifiedEntry `yaml:"samples,omitempty" json:"samples,omitempty"`
 }

--- a/index/generator/schema/schema.go
+++ b/index/generator/schema/schema.go
@@ -40,6 +40,7 @@ Sample index file:
     ],
     "projectType": "maven",
     "language": "java",
+	"lastModified": "2024-05-13T12:32:02+02:00",
     "versions": [
       {
         "version": "1.1.0",
@@ -63,7 +64,8 @@ Sample index file:
         ],
         "starterProjects": [
           "springbootproject"
-        ]
+        ],
+		"lastModified": "2024-05-13T12:32:02+02:00"
       }
     ]
   },
@@ -81,6 +83,7 @@ Sample index file:
     ],
     "projectType": "quarkus",
     "language": "java",
+	"lastModified": "2024-04-29T17:08:43+03:00",
     "versions": [
       {
         "version": "1.1.0",
@@ -110,7 +113,8 @@ Sample index file:
         "starterProjects": [
           "community",
           "redhat-product"
-        ]
+        ],
+		"lastModified": "2024-04-29T17:08:43+03:00"
       }
     ]
   }
@@ -138,6 +142,7 @@ starterProjects: string[] - The project templates that can be used in the devfil
 git: *git - The information of remote repositories
 provider: string - The devfile provider information
 versions: []Version - The list of stack versions information
+lastModified: string - The date that a version of this stack/sample was last changed
 */
 
 // Schema is the index file schema
@@ -163,6 +168,7 @@ type Schema struct {
 	Provider          string                       `yaml:"provider,omitempty" json:"provider,omitempty"`
 	SupportUrl        string                       `yaml:"supportUrl,omitempty" json:"supportUrl,omitempty"`
 	Versions          []Version                    `yaml:"versions,omitempty" json:"versions,omitempty"`
+	LastModified      string                       `yaml:"lastModified,omitempty" json:"lastModified,omitempty"`
 }
 
 // DevfileType describes the type of devfile

--- a/index/generator/tests/registry/index_main.json
+++ b/index/generator/tests/registry/index_main.json
@@ -8,6 +8,7 @@
     "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/golang.svg",
     "projectType": "go",
     "language": "go",
+    "lastModified": "2023-11-08T12:54:08Z",
     "provider": "Red Hat",
     "versions": [
       {
@@ -28,7 +29,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2023-04-08"
+        "lastModified": "2023-04-08T11:51:08Z"
       },
       {
         "version": "1.1.0",
@@ -49,7 +50,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2023-11-08"
+        "lastModified": "2023-11-08T12:54:08Z"
       }
     ]
   },
@@ -62,6 +63,7 @@
     "tags": ["Java", "Maven"],
     "projectType": "maven",
     "language": "java",
+    "lastModified": "2024-05-13T12:32:02+02:00",
     "provider": "Red Hat",
     "versions": [
       {
@@ -83,7 +85,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2024-05-13"
+        "lastModified": "2024-05-13T12:32:02+02:00"
       }
     ]
   },
@@ -95,6 +97,7 @@
     "type": "stack",
     "projectType": "docker",
     "language": "java",
+    "lastModified": "2024-04-23T06:20:34-04:00",
     "provider": "Red Hat",
     "versions": [
       {
@@ -115,7 +118,7 @@
           "run": true,
           "test": true
         },
-        "lastModified": "2024-04-23"
+        "lastModified": "2024-04-23T06:20:34-04:00"
       }
     ]
   },
@@ -128,6 +131,7 @@
     "tags": ["Java", "Quarkus"],
     "projectType": "quarkus",
     "language": "java",
+    "lastModified": "2024-04-29T17:08:43+03:00",
     "provider": "Red Hat",
     "versions": [
       {
@@ -149,7 +153,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2024-04-29"
+        "lastModified": "2024-04-29T17:08:43+03:00"
       }
     ]
   },
@@ -162,6 +166,7 @@
     "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/spring.svg",
     "projectType": "spring",
     "language": "java",
+    "lastModified": "2024-05-13T12:32:02+02:00",
     "versions": [
       {
         "version": "1.1.0",
@@ -182,7 +187,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2024-05-13"
+        "lastModified": "2024-05-13T12:32:02+02:00"
       }
     ]
   },
@@ -195,6 +200,7 @@
     "tags": ["Java", "Vert.x"],
     "projectType": "vertx",
     "language": "java",
+    "lastModified": "2024-05-13T12:32:02+02:00",
     "versions": [
       {
         "version": "1.1.0",
@@ -235,7 +241,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2024-05-13"
+        "lastModified": "2024-05-13T12:32:02+02:00"
       }
     ]
   },
@@ -248,6 +254,7 @@
     "tags": ["Java", "WildFly"],
     "projectType": "wildfly",
     "language": "java",
+    "lastModified": "2024-04-22T23:00:14+02:00",
     "versions": [
       {
         "version": "1.0.0",
@@ -277,7 +284,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2024-04-22"
+        "lastModified": "2024-04-22T23:00:14+02:00"
       }
     ]
   },
@@ -290,6 +297,7 @@
     "tags": ["RHEL8", "Java", "OpenJDK", "Maven", "WildFly", "Microprofile", "WildFly Bootable"],
     "projectType": "WildFly",
     "language": "java",
+    "lastModified": "2024-05-27T11:00:03+02:00",
     "versions": [
       {
         "version": "1.0.0",
@@ -327,7 +335,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2024-05-27"
+        "lastModified": "2024-05-27T11:00:03+02:00"
       }
     ]
   },
@@ -340,6 +348,7 @@
     "tags": ["NodeJS", "Express", "ubi8"],
     "projectType": "nodejs",
     "language": "nodejs",
+    "lastModified": "2024-03-25T12:16:30-04:00",
     "versions": [
       {
         "version": "1.0.0",
@@ -360,7 +369,7 @@
           "run": true,
           "test": true
         },
-        "lastModified": "2024-03-25"
+        "lastModified": "2024-03-25T12:16:30-04:00"
       }
     ]
   },
@@ -373,6 +382,7 @@
     "tags": ["Python", "pip"],
     "projectType": "python",
     "language": "python",
+    "lastModified": "2024-05-28T17:20:11+02:00",
     "versions": [
       {
         "version": "1.0.0",
@@ -393,7 +403,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2024-05-28"
+        "lastModified": "2024-05-28T17:20:11+02:00"
       }
     ]
   },
@@ -406,6 +416,7 @@
     "tags": ["Python", "pip", "Django"],
     "projectType": "django",
     "language": "python",
+    "lastModified": "2024-05-28T17:20:11+02:00",
     "versions": [
       {
         "version": "1.0.0",
@@ -426,7 +437,7 @@
           "run": true,
           "test": false
         },
-        "lastModified": "2024-05-28"
+        "lastModified": "2024-05-28T17:20:11+02:00"
       }
     ]
   },
@@ -439,6 +450,7 @@
     "icon": "https://raw.githubusercontent.com/devfile-samples/devfile-stack-icons/main/node-js.svg",
     "projectType": "nodejs",
     "language": "nodejs",
+    "lastModified": "2024-06-05T15:26:11-04:00",
     "versions": [
       {
         "version": "1.0.0",
@@ -449,7 +461,7 @@
           }
         },
         "description": "nodejs with devfile v2.0.0",
-        "lastModified": "2024-06-05"
+        "lastModified": "2024-06-05T15:26:11-04:00"
       },
       {
         "version": "1.0.1",
@@ -461,7 +473,7 @@
           }
         },
         "description": "nodejs with devfile v2.2.0",
-        "lastModified": "2024-06-05"
+        "lastModified": "2024-06-05T15:26:11-04:00"
       }
     ]
   },
@@ -474,6 +486,7 @@
     "icon": "https://raw.githubusercontent.com/elsony/devfile-sample-code-with-quarkus/main/.devfile/icon/quarkus.png",
     "projectType": "quarkus",
     "language": "java",
+    "lastModified": "2024-04-19T11:45:48+01:00",
     "provider": "Red Hat",
     "versions": [
       {
@@ -486,7 +499,7 @@
           }
         },
         "description": "java quarkus with devfile v2.0.0",
-        "lastModified": "2024-04-19"
+        "lastModified": "2024-04-19T11:45:48+01:00"
       }
     ]
   }

--- a/index/generator/tests/registry/index_main.json
+++ b/index/generator/tests/registry/index_main.json
@@ -27,7 +27,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2023-04-08"
       },
       {
         "version": "1.1.0",
@@ -47,7 +48,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2023-11-08"
       }
     ]
   },
@@ -80,7 +82,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-13"
       }
     ]
   },
@@ -111,7 +114,8 @@
           "deploy": false,
           "run": true,
           "test": true
-        }
+        },
+        "lastModified": "2024-04-23"
       }
     ]
   },
@@ -144,7 +148,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-04-29"
       }
     ]
   },
@@ -176,7 +181,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-13"
       }
     ]
   },
@@ -228,7 +234,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-13"
       }
     ]
   },
@@ -269,7 +276,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-04-22"
       }
     ]
   },
@@ -318,7 +326,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-27"
       }
     ]
   },
@@ -350,7 +359,8 @@
           "deploy": false,
           "run": true,
           "test": true
-        }
+        },
+        "lastModified": "2024-03-25"
       }
     ]
   },
@@ -382,7 +392,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-28"
       }
     ]
   },
@@ -414,7 +425,8 @@
           "deploy": false,
           "run": true,
           "test": false
-        }
+        },
+        "lastModified": "2024-05-28"
       }
     ]
   },
@@ -436,7 +448,8 @@
             "origin": "https://github.com/redhat-developer/devfile-sample"
           }
         },
-        "description": "nodejs with devfile v2.0.0"
+        "description": "nodejs with devfile v2.0.0",
+        "lastModified": "2024-06-05"
       },
       {
         "version": "1.0.1",
@@ -447,7 +460,8 @@
             "origin": "https://github.com/nodeshift-starters/devfile-sample"
           }
         },
-        "description": "nodejs with devfile v2.2.0"
+        "description": "nodejs with devfile v2.2.0",
+        "lastModified": "2024-06-05"
       }
     ]
   },
@@ -471,7 +485,8 @@
             "origin": "https://github.com/elsony/devfile-sample-code-with-quarkus.git"
           }
         },
-        "description": "java quarkus with devfile v2.0.0"
+        "description": "java quarkus with devfile v2.0.0",
+        "lastModified": "2024-04-19"
       }
     ]
   }

--- a/index/generator/tests/registry/last_modified.json
+++ b/index/generator/tests/registry/last_modified.json
@@ -1,0 +1,81 @@
+{
+  "stacks": [
+    {
+      "name": "go",
+      "version": "1.1.0",
+      "lastModified": "2023-11-08T12:54:08+00:00"
+    },
+    {
+      "name": "go",
+      "version": "1.2.0",
+      "lastModified": "2023-04-08T11:51:08+00:00"
+    },
+    {
+      "name": "java-maven",
+      "version": "1.1.0",
+      "lastModified": "2024-05-13T12:32:02+02:00"
+    },
+    {
+      "name": "java-openliberty",
+      "version": "0.5.0",
+      "lastModified": "2024-04-23T06:20:34-04:00"
+    },
+    {
+      "name": "java-quarkus",
+      "version": "1.1.0",
+      "lastModified": "2024-04-29T17:08:43+03:00"
+    },
+    {
+      "name": "java-springboot",
+      "version": "1.1.0",
+      "lastModified": "2024-05-13T12:32:02+02:00"
+    },
+    {
+      "name": "java-vertx",
+      "version": "1.1.0",
+      "lastModified": "2024-05-13T12:32:02+02:00"
+    },
+    {
+      "name": "java-wildfly-bootable-jar",
+      "version": "1.0.0",
+      "lastModified": "2024-05-27T11:00:03+02:00"
+    },
+    {
+      "name": "java-wildfly",
+      "version": "1.0.0",
+      "lastModified": "2024-04-22T23:00:14+02:00"
+    },
+    {
+      "name": "nodejs",
+      "version": "1.0.0",
+      "lastModified": "2024-03-25T12:16:30-04:00"
+    },
+    {
+      "name": "python-django",
+      "version": "1.0.0",
+      "lastModified": "2024-05-28T17:20:11+02:00"
+    },
+    {
+      "name": "python",
+      "version": "1.0.0",
+      "lastModified": "2024-05-28T17:20:11+02:00"
+    }
+  ],
+  "samples": [
+    {
+      "name": "nodejs-basic",
+      "version": "1.0.0",
+      "lastModified": "2024-06-05T15:26:11-04:00"
+    },
+    {
+      "name": "nodejs-basic",
+      "version": "1.0.1",
+      "lastModified": "2024-06-05T15:26:11-04:00"
+    },
+    {
+      "name": "code-with-quarkus",
+      "version": "1.1.0",
+      "lastModified": "2024-04-19T11:45:48+01:00"
+    }
+  ]
+}

--- a/index/server/openapi.yaml
+++ b/index/server/openapi.yaml
@@ -277,7 +277,8 @@ paths:
         - $ref: '#/components/parameters/gitRevisionParam'
         - $ref: '#/components/parameters/providerParam'
         - $ref: '#/components/parameters/supportUrlParam'
-        - $ref: '#/components/parameters/lastModifiedParam'
+        - $ref: '#/components/parameters/minLastModifiedParam'
+        - $ref: '#/components/parameters/maxLastModifiedParam'
       responses:
         200:
           $ref: '#/components/responses/v2IndexResponse'
@@ -350,7 +351,8 @@ paths:
         - $ref: '#/components/parameters/gitRevisionParam'
         - $ref: '#/components/parameters/providerParam'
         - $ref: '#/components/parameters/supportUrlParam'
-        - $ref: '#/components/parameters/lastModifiedParam'
+        - $ref: '#/components/parameters/minLastModifiedParam'
+        - $ref: '#/components/parameters/maxLastModifiedParam'
       responses:
         200:
           $ref: '#/components/responses/v2IndexResponse'
@@ -882,7 +884,9 @@ components:
           $ref: '#/components/schemas/Provider'
         supportUrl:
           $ref: '#/components/schemas/Url'
-        lastModified:
+        minLastModified:
+          $ref: '#/components/schemas/LastModified'
+        maxLastModified:
           $ref: '#/components/schemas/LastModified'
     Name:
       description: Name of devfile registry entry
@@ -1023,6 +1027,8 @@ components:
     LastModified:
       description: Last modified date of a stack or sample
       type: string
+      pattern: '^\d{4}\-(0[1-9]|1[012])\-(0[1-9]|[12][0-9]|3[01])$'
+      example: '2024-01-01'
   parameters:
     nameParam:
       name: name
@@ -1259,11 +1265,18 @@ components:
       description: Search string to filter stacks by their given support url
       schema:
         $ref: '#/components/schemas/Url'
-    lastModifiedParam:
-      name: lastModified
+    minLastModifiedParam:
+      name: minLastModified
       in: query
       required: false
-      description: Search string to filter stacks or samples by their last modified date
+      description: The minimum (earliest) last modified date of a stack or sample
+      schema:
+        $ref: '#/components/schemas/LastModified'
+    maxLastModifiedParam:
+      name: maxLastModified
+      in: query
+      required: false
+      description: The maximum (latest) last modified date of a stack or sample
       schema:
         $ref: '#/components/schemas/LastModified'
   responses:

--- a/index/server/openapi.yaml
+++ b/index/server/openapi.yaml
@@ -121,7 +121,6 @@ paths:
         - $ref: '#/components/parameters/gitRevisionParam'
         - $ref: '#/components/parameters/providerParam'
         - $ref: '#/components/parameters/supportUrlParam'
-        - $ref: '#/components/parameters/lastModifiedParam'
       responses:
         200:
           $ref: '#/components/responses/indexResponse'
@@ -187,7 +186,6 @@ paths:
         - $ref: '#/components/parameters/gitRevisionParam'
         - $ref: '#/components/parameters/providerParam'
         - $ref: '#/components/parameters/supportUrlParam'
-        - $ref: '#/components/parameters/lastModifiedParam'
       responses:
         200:
           $ref: '#/components/responses/indexResponse'

--- a/index/server/openapi.yaml
+++ b/index/server/openapi.yaml
@@ -121,6 +121,7 @@ paths:
         - $ref: '#/components/parameters/gitRevisionParam'
         - $ref: '#/components/parameters/providerParam'
         - $ref: '#/components/parameters/supportUrlParam'
+        - $ref: '#/components/parameters/lastModifiedParam'
       responses:
         200:
           $ref: '#/components/responses/indexResponse'
@@ -186,6 +187,7 @@ paths:
         - $ref: '#/components/parameters/gitRevisionParam'
         - $ref: '#/components/parameters/providerParam'
         - $ref: '#/components/parameters/supportUrlParam'
+        - $ref: '#/components/parameters/lastModifiedParam'
       responses:
         200:
           $ref: '#/components/responses/indexResponse'
@@ -277,6 +279,7 @@ paths:
         - $ref: '#/components/parameters/gitRevisionParam'
         - $ref: '#/components/parameters/providerParam'
         - $ref: '#/components/parameters/supportUrlParam'
+        - $ref: '#/components/parameters/lastModifiedParam'
       responses:
         200:
           $ref: '#/components/responses/v2IndexResponse'
@@ -349,6 +352,7 @@ paths:
         - $ref: '#/components/parameters/gitRevisionParam'
         - $ref: '#/components/parameters/providerParam'
         - $ref: '#/components/parameters/supportUrlParam'
+        - $ref: '#/components/parameters/lastModifiedParam'
       responses:
         200:
           $ref: '#/components/responses/v2IndexResponse'
@@ -880,6 +884,8 @@ components:
           $ref: '#/components/schemas/Provider'
         supportUrl:
           $ref: '#/components/schemas/Url'
+        lastModified:
+          $ref: '#/components/schemas/LastModified'
     Name:
       description: Name of devfile registry entry
       type: string
@@ -1015,6 +1021,9 @@ components:
       type: string
     Provider:
       description: Name of provider of the devfile registry entry
+      type: string
+    LastModified:
+      description: Last modified date of a stack or sample
       type: string
   parameters:
     nameParam:
@@ -1252,6 +1261,13 @@ components:
       description: Search string to filter stacks by their given support url
       schema:
         $ref: '#/components/schemas/Url'
+    lastModifiedParam:
+      name: lastModified
+      in: query
+      required: false
+      description: Search string to filter stacks or samples by their last modified date
+      schema:
+        $ref: '#/components/schemas/LastModified'
   responses:
     devfileErrorResponse:
       description: Failed to get the devfile.

--- a/index/server/pkg/server/endpoint.gen.go
+++ b/index/server/pkg/server/endpoint.gen.go
@@ -999,14 +999,6 @@ func (siw *ServerInterfaceWrapper) ServeDevfileIndexV1(c *gin.Context) {
 		return
 	}
 
-	// ------------- Optional query parameter "lastModified" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "lastModified", c.Request.URL.Query(), &params.LastModified)
-	if err != nil {
-		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter lastModified: %s", err), http.StatusBadRequest)
-		return
-	}
-
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -1253,14 +1245,6 @@ func (siw *ServerInterfaceWrapper) ServeDevfileIndexV1WithType(c *gin.Context) {
 	err = runtime.BindQueryParameter("form", true, false, "supportUrl", c.Request.URL.Query(), &params.SupportUrl)
 	if err != nil {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter supportUrl: %s", err), http.StatusBadRequest)
-		return
-	}
-
-	// ------------- Optional query parameter "lastModified" -------------
-
-	err = runtime.BindQueryParameter("form", true, false, "lastModified", c.Request.URL.Query(), &params.LastModified)
-	if err != nil {
-		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter lastModified: %s", err), http.StatusBadRequest)
 		return
 	}
 
@@ -2057,64 +2041,64 @@ func RegisterHandlersWithOptions(router *gin.Engine, si ServerInterface, options
 var swaggerSpec = []string{
 
 	"H4sIAAAAAAAC/+xdW4/btrP/KoROgZPgaO2NmxbovhRt06QLtDnBXnIe6hyAlsY2G4lUSMq77sLf/Q/e",
-	"dLEkm75tNolekl2LHP5mOBz+OCNzH4KIpRmjQKUILh6CDHOcggSuf8M8mr9Tn6hfYhARJ5kkjAYXwW8s",
-	"SSBSvyA2RQJUUyQkJ3QmkGRoShIJHAmJo48CTZZIzoFwpJoRCZHMOYggDIiS9SkHvgzCgOIUggs9ahAG",
-	"IppDitXI33GYBhfBfw1LrEPzVAx/qQlcrcIAS8nJJJfwFqcgjggfKXxCtR/TGKaEQoymHOBsyniKimE7",
-	"1arhqilIJKTa4HKZqaYGSLAK3QeYc7zU2kUsTTGN33CWZ+K4c5NxEEAlskOgMZ3pUTr0qSHxnq/far2U",
-	"RjFMcZ7IDl1+ZSwBTJuwyVTBXiLMAVkRiHFEmezAaxt5I31l2xuMWcKWKVB5HbEMTmT4cpQxFXqcTlXq",
-	"cHbQaa2jVY5DhCXEh82Bk7JtGly7XVC7LgZvAa4D8HXV8p3LudIHSbjvBlyK9kdc9tGQicgSvFQr/xDI",
-	"hCMrycSiLsTlaP6IK30U4hmRV5AyE60OxDwjEnEtTMPuQF0b0Rv3m1qvBvJTxX/1a6mW8FFJ7KeTqCt1",
-	"VIVury7302cPXSp6LIg4cO0WTmVEbYJbtNgBr+1jAV/nk1eEHwhXYj4DiUQ+iQmHSDK+RGPKdAC1umRM",
-	"EPV5tzYGyS662B5Wk1ueHMHqOU82OMgtT7wBqrYKGok63eGGzWYJIEYR0IjFCl3EqFTbZYaF0LtIGxIl",
-	"0hvHZWRnW/W65eRAIykpKOdkA7Rb/dQfnWqvACaYznI8OzQiZ5zNOE5T1cqJ7EBbeewH90/XweAV8i8W",
-	"kynpZBdbMDOOBE6zBCrwlVSUWrEoxrIbfDn8DgpUOmklCP14os2kCAFqDCRYzqPO6FvA8Nek6OHUODJz",
-	"1ajHdDvu3TAbvCm+v9Yfvge+YcO4mQNK8T1J8xTFsJiSBJARhhamYweudfneEOu9LFR/kNqI27HtiqqG",
-	"h1Bv0xG6h+nW5B9iOkL9QXqZrhC4l+no4Xx3A8mlu3DbgtJmnP0DkbxZZkcI/EoS0nmFdoiVwbyRvqv0",
-	"sYAXJIaDSJOdbCeqG6177A3VdFA4OdjQddywOKZOsGrRGRiL0b3BXxU9FHohMZfArfFPuTvZkZz7dCm0",
-	"Bsg/Kqz108rlWcb4USjrAiiy4hR57QJfDLgzf5V4dmQPUhI7cNpHe2QPjcNnjAoQBqkO+b9zzviVfaA+",
-	"twRbZ4CzLCERVviH/wil0UNl5IyzDLgkRhwoOU0cYXB/NmNnFr0eLDDOK3Oxrfm1abUqlWET5SMm01sB",
-	"t8Rp8oTA1dNUwUXwGpMEYjXj6hho0k/a+oNAt9U/v2XyNctpfITJeGTzntJgU0LjLovtZanNmTst18MA",
-	"flIael3nUQRCTPMEKQNq6YMxHdNrvd05GmaV0brOASdyfgSnSEEIdTLbMk1/2WYmYHzKCYc4uPi76P7h",
-	"UG85HQ5/c/+hjYqM42ozExrD/dEd6lJJNbT3QKeqS/LXVPerOVQKcs7it0z+kiTsDuLetfZxrb+0FVEu",
-	"IEZEIMqkYxkQD4IGP/Mw8r8kq+s2ZTzFMrgIJoRiTQLW9vgd3OC1CiuTpQTNO2J2RxOGDdDF6HJv39dW",
-	"daj0pwPro2H57Iykyi6mwiznJlM4zyeDiKVDG/KGHGZESL48s1Yc6gU5nAFVajBuF4JRerNPfBZQ/lPx",
-	"foTWF+XKMTrtxfWqdoNU/q/+AScoIUIqXplxpkZiawV2JOe4Rjacg4oQQZrJpREg8tkMhGxpHmGKJmBc",
-	"nFGE6bI2gGKojnzWEVYVsIW2icYDNQHuHAo0T9Xyw2n848sgDDBP9f9ZFv34MtHn0O9/Or+vLMsukhsG",
-	"9QpzA9mf1mSuym1q3MgV9Al1yleVc/gmOUniIAx4TtVaBCEDNemTfBa4IvF2jGGQU/Iph0sjXfIcVmHg",
-	"ys0NwK8TPENTxosqt5sc55oIqPq3zIrY0SambBto4Wt1306zlKVlZErQxilMhVfNmrFRxUna7EQoBZ4w",
-	"lgVhwHJpf97bMkX5d5NxivJzu3067FIRti678tBYZrPYUifH/jokuoUgJM/NKmBThFGUsDw+o1iShbbt",
-	"HeMfRYYjQMpNY1hAwjI9MUAXhDOa6sgR1oLd4gVOsjkeDV4Vk7NbvMMZGS5Gw+zjTP0ohgUKMXSydbCq",
-	"1osbet4K4IgDjvEkMbmE3QxYL+o2xL+plcvWSsubhW3w/FmnVFF18R2K0V7eXSmQ7gjN1eF8kOlMRTNW",
-	"Vqudzdc+OKbRPEQSz0LEuI6YGsgUONCoy9i25NjM11RLn02lJFPbDMJi8wC6VNe9ITof0yW4omJod5lW",
-	"Ybec+MrLOQndlojR7dWfyioYcUjMolWrygVHmylrHbXC41uz3ZpioEo2fm2RPxajCYOiltfA+a6lgohs",
-	"ttAZrYgdbVaoVdmant+o8JkgaXLCRU2wVXBR9GpIfete4HAIXWnKM4XWvoJNxWrDjtox1h7rtT0evt05",
-	"wFbz9U0XXGZgSaWpFbTwxw6hJrPeCdAl69cdZTvgMvHdaWcrybbTpKCDpWylkPUqVcs23lYqQzRPJ7oQ",
-	"AffGOS+C0WA0OA+R+u/7M717KlKLpQSuBP3/3+dnP334n/F4YH54Vv3JtH/+8/Ofv2uzyHrOvNMua7n7",
+	"dLEkm75tNoleEq9NDn8zHA5/nJHphyBiacYoUCmCi4cgwxynIIHrvzCP5u/UO+qPGETESSYJo8FF8BtL",
+	"EojUH4hNkQDVFAnJCZ0JJBmakkQCR0Li6KNAkyWScyAcqWZEQiRzDiIIA6JkfcqBL4MwoDiF4EKPGoSB",
+	"iOaQYjXydxymwUXwX8MS69B8Koa/1ASuVmGApeRkkkt4i1MQR4SPFD6h2o9pDFNCIUZTDnA2ZTxFxbCd",
+	"atVw1RQkElJtcLnMVFMDJFiF7g3MOV5q7SKWppjGbzjLM3Hcuck4CKAS2SHQmM70KB361JB4z9dvtV5K",
+	"oximOE9khy6/MpYApk3YZKpgLxHmgKwIxDiiTHbgtY28kb6y7Q3GLGHLFKi8jlgGJzJ8OcqYCj1Opyp1",
+	"ODvotNbRKschwhLiw+bASdk2Da7dLqhdF4O3ANcB+Lpq+c7lXOmDJNx3Ay5F+yMu+2jIRGQJXqqVfwhk",
+	"wpGVZGJRF+JyNH/ElT4K8YzIK0iZiVYHYp4RibgWpmF3oK6N6I37Ta1XA/mp4r/6s1RL+Kgk9tNJ1JU6",
+	"qkK3V5f76bOHLhU9FkQcuHYLpzKiNsEtWuyA1/axgK/zySvCD4QrMZ+BRCKfxIRDJBlfojFlOoBaXTIm",
+	"iHq/WxuDZBddbA+ryS1PjmD1nCcbHOSWJ94AVVsFjUSd7nDDZrMEEKMIaMRihS5iVKrtMsNC6F2kDYkS",
+	"6Y3jMrKzrXrdcnKgkZQUlHOyAdqt/tQfnWqvACaYznI8OzQiZ5zNOE5T1cqJ7EBb+dgP7p+ug8Er5F8s",
+	"JlPSyS62YGYcCZxmCVTgK6kotWJRjGU3+HL4HRSodNJKEPrxRJtJEQLUGEiwnEed0beA4a9J0cOpcWTm",
+	"qlGP6Xbcu2E2eFN8f63ffA98w4ZxMweU4nuS5imKYTElCSAjDC1Mxw5c6/K9IdZ7Waj+ILURt2PbFVUN",
+	"D6HepiN0D9OtyT/EdIT6g/QyXSFwL9PRw/nuBpJLd+G2BaXNOPsHInmzzI4Q+JUkpPMK7RArg3kjfVfp",
+	"YwEvSAwHkSY72U5UN1r3sTdU00Hh5GBD13HD4pg6wapFZ2AsRvcGf1X0UOiFxFwCt8Y/5e5kR3Lu06XQ",
+	"GiD/qLDWTyuXZxnjR6GsC6DIilPktQt8MeDO/FXi2ZE9SEnswGk/2iN7aBw+Y1SAMEh1yP+dc8av7Afq",
+	"fUuwdQY4yxISYYV/+I9QGj1URs44y4BLYsSBktPEEQb3ZzN2ZtHrwQLjvDIX25pfm1arUhk2UT5iMr0V",
+	"cEucJk8IXD1NFVwErzFJIFYzro6BJv2krT8IdFv9+i2Tr1lO4yNMxiOb95QGmxIad1lsL0ttztxpuR4G",
+	"8JPS0Os6jyIQYponSBlQSx+M6Zhe6+3O0TCrjNZ1DjiR8yM4RQpCqJPZlmn6yzYzAeNTTjjEwcXfRfcP",
+	"h3rL6XD4m/sPbVRkHFebmdAY7o/uUJdKqqG9BzpVXZK/prpfzaFSkHMWv2XylyRhdxD3rrWPa/2lrYhy",
+	"ATEiAlEmHcuAeBA0+JmHkf8lWV23KeMplsFFMCEUaxKwtsfv4AavVViZLCVo3hGzO5owbIAuRpd7+762",
+	"qkOl3x1YHw3Lz85IquxiKsxybjKF83wyiFg6tCFvyGFGhOTLM2vFoV6QwxlQpQbjdiEYpTf7xGcB5T8V",
+	"70dofVGuHKPTXlyvajdI5f/qFzhBCRFS8cqMMzUSWyuwIznHNbLhHFSECNJMLo0Akc9mIGRL8whTNAHj",
+	"4owiTJe1ARRDdeSzjrCqgC20TTQeqAlw51CgeaqWH07jH18GYYB5qv/PsujHl4k+h37/0/l9ZVl2kdww",
+	"qFeYG8j+tCZzVW5T40auoE+oU76qnMM3yUkSB2HAc6rWIggZqEmf5LPAFYm3YwyDnJJPOVwa6ZLnsAoD",
+	"V25uAH6d4BmaMl5Uud3kONdEQNW/ZVbEjjYxZdtAC1+r+3aapSwtI1OCNk5hKrxq1oyNKk7SZidCKfCE",
+	"sSwIA5ZL+3pvyxTl303GKcrP7fbpsEtF2LrsyofGMpvFljo59tch0S0EIXluVgGbIoyihOXxGcWSLLRt",
+	"7xj/KDIcAVJuGsMCEpbpiQG6IJzRVEeOsBbsFi9wks3xaPCqmJzd4h3OyHAxGmYfZ+qlGBYoxNDJ1sGq",
+	"Wi9u6HkrgCMOOMaTxOQSdjNgvajbEP+mVi5bKy1vFrbB82edUkXVxXcoRnt5d6VAuiM0V4fzQaYzFc1Y",
+	"Wa12Nh/74JhG8xBJPAsR4zpiaiBT4ECjLmPbkmMzX1MtfTaVkkxtMwiLzQPoUl33huh8TJfgioqh3WVa",
+	"hd1y4isv5yR0WyJGt1d/KqtgxCExi1atKhccbaasddQKj2/NdmuKgSrZ+LVF/liMJgyKWl4D57uWCiKy",
+	"2UJntCJ2tFmhVmVren6jwmeCpMkJFzXBVsFF0ash9a17gMMhdKUpzxRa+wo2FasNO2rHWHus1/Z4+Hbn",
+	"AFvN1zddcJmBJZWmVtDCHzuEmsx6J0CXrF93lO2Ay8R3p52tJNtOk4IOlrKVQtarVC3beFupDNE8nehC",
+	"BNwb57wIRoPR4DxE6r/vz/TuqUgtlhK4EvT/f5+f/fThf8bjgXnxrPrKtH/+8/Ofv2uzyHrOvNMua7n7",
 	"5o7WPlfr3arFin1WifLoJlHgCZoSSOLOEL11EtpZcNtkvBi8HJx72r/V6OqMBlHOiVxqDzHeOMGCRMXx",
-	"UxNM/UnRfS5lZg6thE5ZiyYsyhWXw51M8+r36xv0y7tLfXi8aVs4rgUiwpzWlPsTKoHjSKoYfUfkvNFt",
+	"UxNM/U7RfS5lZg6thE5ZiyYsyhWXw51M8+r36xv0y7tLfXi8aVs4rgUiwpzWlPsTKoHjSKoYfUfkvNFt",
 	"gC7VbkUEiqsYQr1w5kxIJU4AX+hNVO1q+SQhUUNOiJYs1ztjNMd0BohItZ8vWc4Ru6NW1FS3usNUus0+",
-	"42ShQnsDlzIekXrWXnUaIwgDd+ZRk3s+eKEchmVAcUaCi+B7/ZGe77meqaGxfQJSR73iTH4Z63HU51eM",
+	"42ShQnsDlzIekXrWXnUaIwgDd+ZRk3s+eKEchmVAcUaCi+B7/Zae77meqaGxfQJSR73iTH4Z63HU+1eM",
 	"yd9pnDFC1d5dK5e8PP+hK2wX7YadqTXtADOQbYUsKVCeGaNjGifAi+jFGZPo2fA5AgtKHcP14QH4AviY",
-	"Xk7RXKaJmigOn3IQ6gT0jAxggKacpQijO5igCWd3AvhzM7MLAnfAVRf7pijEIWJyDvyOCKhFZkNFrBdA",
-	"rGxeN9u1+nyT1eLyXPuk86nqOH8vh8qYwcVDM5mjdEROM5uwydMU86V7WE7RtPRWM086y5YxIZt+944J",
-	"eWKvy/K2cfPTDrsKA0c5xfBB87bV9vVXHlur30T5u40lGypYfddCc95qMTr6GFTTu2onqhZOt5Sqoo9q",
-	"1lo+/PBIgeEKZM7tcs8gIlMSWa3XqkRtm0bHUv0iDBy2G7NEPGx/wcmnY+tLZWZKdfj8lcXLerBqhAJl",
-	"HNsaTVi8RGmufgKTU9VrveYfo/Pz7f6xXtBchcHL85fe/Rql41UY/LDDuPWXAOrR7Q2UScfJsuIXep/G",
-	"M+VAriAbfNgY6b7V9d0Vgr9Ne7TtDUN74Dhz7xjpB5Ujjv/uUT8aPflQ1wqncWRziaXaBtCJtq7/3rCr",
-	"Ylabnz7WpvgaZDQH0bCR3SFNeaKkwiURq22c+jg0pvb88N+i2EkxjV2aQiBMTbVqAejZvyR7bnIMrnSK",
-	"sMnj/3Fz867CDDdtu71nfgbP/ExsYlcC0PG2QMkD1hKweAb6nYOp2vYHx9zvu5ZYsffbRVJ4QOCz5/e+",
-	"/3VE5S1Upp/mr2GaWxnag90u/ZnY/xE5L7+M8aV5gsslly/B69FbgJXvXuwHrfgCSsfHX0HGoXeF47hC",
-	"nxv5ynMj/UJ5sjFzC/XpZ+6JztxmNnOyzFPvD0fb8nqa/o3myPo11K+hPpt30myeMnRYv1ohPEaKr1+6",
-	"/dJ9UsnI3iF7hzx92tR8W3v7kcF8Afm3OVgnetz0XuMN0nn9+9CtDG0DZK9Nce2L7N6bYSPj0gDrMi3m",
-	"dbstiZbTWr4rJJ1yVOV3+lVN75Oqfvnx/YvgkU8k+p1W53KV77lU0sr1Q4ha7GhM9bustUPExjNEqd1a",
-	"lN/CAMvLnzzoYuNSV58+63fXevRpu9Dao1t5KY3PGMVN3x6Ny+saPRsXVyp6tG/cdeXRp34rotc01K88",
-	"9uiydlWUR4/W65l8tKlfN+jZw7912wW5u3TbqUtxf9OuwHbpVb2h1Xec6iW0fm5ZudHMZ/bX7q/ycuP1",
-	"yzKfQO2lfivK3lu2sNHevnxfY7Eu2Iu9ayan2822HDBONXCxoQ8f9H8qHK523dzVecde47f1sFPbb82l",
-	"ZO1EvYCzN0e/LCSsOh98eIK8xBXEj0JNvuC5CXsa1dOonkb1NKqnUU+FRjkCVdunVJw/lFH1FGJ3Mtjb",
-	"rM5jF6N9UlOjz5qacsn2UQcZHNOWNNVeTHDUJ6l6dtVVx96jgr1zlyNXy0/CGmt/I+6bYpktf+/Pz8Qt",
-	"f6+uJ7U9qT0qqV2/N/YAWvt+9AgJwtHnShCOghMSqwNShKOeq56AH+o/m9GeLtyPIvbJwp7O9nS2p7M9",
-	"ne3pbE9nv2Q6e6pEbU/k9iDlvc0q5wl9uSlfOAvkPLFXl4qLYXFn9EBIPIOB+0NMhA31Yu9oXGv2YfWf",
-	"AAAA//+adPhkbIIAAA==",
+	"Xk7RXKaJmigOn3IQ6gT0jAxggKacpQijO5igCWd3AvhzM7MLAnfAVRf7pCjEIWJyDvyOCKhFZkNFrBdA",
+	"rGxeN9u1en+T1eLyXPuk86nqOH8vh8qYwcVDM5mjdEROM5uwydMU86X7sJyiaemtZp50li1jQjb97h0T",
+	"8sRel+Vt4+anHXYVBo5yiuGD5m2r7euvPLZWv4nydxtLNlSw+qyF5rzVYnT0Maimd9VOVC2cbilVRR/V",
+	"rLW8+eGRAsMVyJzb5Z5BRKYkslqvVYnaNo2OpfpFGDhsN2aJeNj+gJNPx9aHysyU6vD5K4uX9WDVCAXK",
+	"OLY1mrB4idJcvQKTU9VrveYfo/Pz7f6xXtBchcHL85fe/Rql41UY/LDDuPWHAOrR7Q2UScfJsuIXep/G",
+	"M+VAriAbfNgY6b7V9d0Vgr9Ne7TtDUN74DhzzxjpDypHHP/do340evKhrhVO48jmEku1DaATbV3/vWFX",
+	"xaw2f/pYm+JrkNEcRMNGdoc05YmSCpdErLZx6uPQmNrzw3+LYifFNHZpCoEwNdWqBaBn/5LsuckxuNIp",
+	"wiaP/8fNzbsKM9y07fae+Rk88zOxiV0JQMfTAiUPWEvA4hnoZw6matsfHHO/71pixd5vF0nhAYHPnt/7",
+	"/tcRlbdQmX6av4ZpbmVoD3a79Gdi/0fkvPwyxpfmCS6XXD4Er0dvAVY+e7EftOILKB1vfwUZh94VjuMK",
+	"fW7kK8+N9AvlycbMLdSnn7knOnOb2czJMk+9Pxxty+tp+jeaI+vXUL+G+mzeSbN5ytBh/WqF8Bgpvn7p",
+	"9kv3SSUje4fsHfL0aVPzbe3tRwbzBeTf5mCd6HHTe40nSOf170O3MrQNkL02xbUvsntvho2MSwOsy7SY",
+	"x+22JFpOa/mukHTKUZXf6Uc1vU+q+uHH9y+CRz6R6GdanctVvudSSSvXDyFqsaMx1c+y1g4RG88QpXZr",
+	"UX4LAywvf/Kgi41LXX36rN9d69Gn7UJrj27lpTQ+YxQ3fXs0Lq9r9GxcXKno0b5x15VHn/qtiF7TUL/y",
+	"2KPL2lVRHj1ar2fy0aZ+3aBnD//WbRfk7tJtpy7F/U27AtulV/WGVt9xqpfQ+rll5UYzn9lfu7/qCZRR",
+	"6hec7L37Chu47XP0NULq4rbYu/xxuo1py1nhVAMXe/PwQf+nIttq131aHV3sjXxbzy21rdPcL9bOuQs4",
+	"e9Pty0LCqvODD0+QYrja9lFYxhc8N2HPiHpG1DOinhH1jOgEjMhxodqWo0L2oeSoZwO787reZnVKuhjt",
+	"kzAafdaEkUuBjzp43Zi2JI/2InWjPnXUE6Wu6vIedeWduxy5hn0SAlj75bZvijC2/Aqfn4lbfkWu56dP",
+	"lZ/6RI/1n7d5AqR2/TbXA2jt+9Ej5PpGnyvXNwpOSKwOyPaNeq56An6of8yiPfO3H0Xs8349ne3pbE9n",
+	"ezrb09mezn7JdPZUidqeyO1BynubVc4T+spRvnAWyHliLxQVF8PiJueBkHgGA/fzSIQN9WLvaFxr9mH1",
+	"nwAAAP//VPY9BAKCAAA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/index/server/pkg/server/endpoint.gen.go
+++ b/index/server/pkg/server/endpoint.gen.go
@@ -999,6 +999,14 @@ func (siw *ServerInterfaceWrapper) ServeDevfileIndexV1(c *gin.Context) {
 		return
 	}
 
+	// ------------- Optional query parameter "lastModified" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "lastModified", c.Request.URL.Query(), &params.LastModified)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter lastModified: %s", err), http.StatusBadRequest)
+		return
+	}
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -1245,6 +1253,14 @@ func (siw *ServerInterfaceWrapper) ServeDevfileIndexV1WithType(c *gin.Context) {
 	err = runtime.BindQueryParameter("form", true, false, "supportUrl", c.Request.URL.Query(), &params.SupportUrl)
 	if err != nil {
 		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter supportUrl: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "lastModified" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "lastModified", c.Request.URL.Query(), &params.LastModified)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter lastModified: %s", err), http.StatusBadRequest)
 		return
 	}
 
@@ -1555,6 +1571,14 @@ func (siw *ServerInterfaceWrapper) ServeDevfileIndexV2(c *gin.Context) {
 		return
 	}
 
+	// ------------- Optional query parameter "lastModified" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "lastModified", c.Request.URL.Query(), &params.LastModified)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter lastModified: %s", err), http.StatusBadRequest)
+		return
+	}
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -1860,6 +1884,14 @@ func (siw *ServerInterfaceWrapper) ServeDevfileIndexV2WithType(c *gin.Context) {
 		return
 	}
 
+	// ------------- Optional query parameter "lastModified" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "lastModified", c.Request.URL.Query(), &params.LastModified)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter lastModified: %s", err), http.StatusBadRequest)
+		return
+	}
+
 	for _, middleware := range siw.HandlerMiddlewares {
 		middleware(c)
 	}
@@ -2024,64 +2056,65 @@ func RegisterHandlersWithOptions(router *gin.Engine, si ServerInterface, options
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xda4/bttL+K4TeAm+Co7U3blqg+6VomyZdoM0J9pLzoc4BaGlss5FIhaS86y783w94",
-	"08WSbPq22Sb6kuxa5PDhcDjzcEbmPgQRSzNGgUoRXDwEGeY4BQlc/4Z5NH+nPlG/xCAiTjJJGA0ugl9Y",
-	"kkCkfkFsigSopkhITuhMIMnQlCQSOBISRx8FmiyRnAPhSDUjEiKZcxBBGBAl61MOfBmEAcUpBBd61CAM",
-	"RDSHFKuRv+EwDS6C/xuWWIfmqRj+VBO4WoUBlpKTSS7hLU5BHBE+UviEaj+mMUwJhRhNOcDZlPEUFcN2",
-	"TquGqzZBIiHVCpfLTDU1QIJV6D7AnOOlnl3E0hTT+A1neSaOuzYZBwFUIjsEGtOZHqVjPjUk3uv1S62X",
-	"mlEMU5wnsmMuPzOWAKZN2GSqYC8R5oCsCMQ4okx24LWNvJG+su0NxixhyxSovI5YBidSfDnKmAo9TudU",
-	"6nB2mNNaRzs5DhGWEB+2Bk7KtmVw7XZB7boYvAW4DsDXVc13budKHyThvhtwKdofcdlHQyYiS/BS7fxD",
-	"IBOOrCTji7oQl6P5I670UYhnRF5Byoy3OhDzjEjEtTANuwN1bURv3G9qvRrIT+X/1a/ltITPlMR+cxL1",
-	"SR11QrdXl/vNZ4+5VOaxIOLAvVsYlRG1CW7RYge8to8FfJ1PXhF+IFyJ+QwkEvkkJhwiyfgSjSnTDtTO",
-	"JWOCqM+7Z2OQ7DIX28PO5JYnR9B6zpMNBnLLE2+Aqq2CRqJOc7hhs1kCiFEENGKxQhcxKlW4zLAQOoq0",
-	"IVEivXFcRna1Va9bTg5UkpKCck42QLvVT/3RqfYKYILpLMezQz1yxtmM4zRVrZzIDrSVx35wf3cdNF5C",
-	"P57IDxe7R42BBMt51Om4Chj+syh6uGkcmfRp1GO6HfdumA3eFN9f6w/fA9/ga2/mgFJ8T9I8RTEspiQB",
-	"ZIShhenYgWtdvjfEei8L1R+kVuJ2bLuiquEh1Ft1hO6hujX5h6iOUH+QXqorBO6lOno4VdzAD+kutLBg",
-	"gxlnf0Ekb5bZEXymkoT0kbwdYmUwb6TvKn0s4AWJ4SC+YRfbiepG6x57QzUdFE4O1nUd1y2OqROsWnQ6",
-	"xmJ0b/BXRQ+FXkjMJXCr/FNGJzuSM5+uCa0B8vcKa/305PIsY/wobG8BFFlxivd1gS8G3Jn6STw7sgUp",
-	"iR047aM9Em/G4DNGBQiDVLv8Xzln/Mo+UJ9bbqqTp1mWkAgr/MO/hJrRQ2XkjLMMuCRGHCg5TRxhcH82",
-	"Y2cWvR4sMMYrc7Gt+bVptSonwybKRkyStAJuidPkCYGrZ3iCi+A1JgnEasXVCcpkbrT2B4Fuq39+y+Rr",
-	"ltP4CIvxyOo9pcKmhMZdGttLU5uTXlquhwL8pDTmdZ1HEQgxzROkFKilD8Z0TK91uHM0zE5Gz3UOOJHz",
-	"IxhFCkKoQ82WZfrDNjMO41NOOMTBxZ9F9w+HWsvpcPir+zetVGQMV6uZ0Bjuj25Ql0qqob0HGlVdkv9M",
-	"db+aQaUg5yx+y+RPScLuIO5Nax/T+kNrEeUCYkQEokw6lgHxIGjwMw8l/02y+tymjKdYBhfBhFCsScBa",
-	"jN/BDF4rtzJZStC8I2Z3NGHYAF2MLve2fa1Vh0p/OrA2GpbPzkiq9GKKs3JukmzzfDKIWDq0Lm/IYUaE",
-	"5Mszq8Wh3pDDGVA1DcbtRjCT3mwTnwWU/1K8H6H1TblyjE5bcb0g3CCV/9Y/4AQlREjFKzPO1EhsrTaN",
-	"5BzXyIYzUBEiSDO5NAJEPpuBkC3NI0zRBIyJM4owXdYGUAzVkc86wuoEbI1qovFATYA7hwLNU7X9cBp/",
-	"/zIIA8xT/X+WRd+/TPQ59Nsfzu8r27KL5IZBvTjbQPa7VZkrEJvyMHK1cELd5KuTc/gmOUniIAx4TtVe",
-	"BCEDteiTfBa4+up2jGGQU/Iph0sjXfIcVmHgKrUNwK8TPENTxosCsVscZ5oIqPq3zIrY0Sam4hlo4Wsl",
-	"0061lFVZZKq3xihMcVStmtFRxUja9EQoBZ4wlgVhwHJpf95bM0XldJNyisptu3469FIRti678tBoZrPY",
-	"ck6O/XVIdBtBSJ6bXcCmCKMoYXl8RrEkC63bO8Y/igxHgJSZxrCAhGV6YYAuCGc01Z4jrDm7xQucZHM8",
-	"GrwqFmc3f4czMlyMhtnHmfpRDAsUYuhka2dVLbU25nkrgCMOOMaTxOQSdlNgvR7aEP+mVmlaq8puFrbB",
-	"8medUkXVxHeo43pZd6W2uCM0V8LyQaYzFU1fWS0UNt+Y4JhG8xBJPAsR49pjaiBT4ECjLmXbal0zX1Ot",
-	"GjYnJZkKMwiLzQPoKld3QHQ2pqtXRbHNRplWYbec+MrLOQldSMTo9up3pRWMOCRm06pd5ZyjzZS1jlrh",
-	"8a3Zbk0xUCUbv7bJH4vRhEFRBmvgfNdSfEM2W+iUVviONi2UtamG7LfuFQUnyFWQPDNd7RvNFJY2BL6O",
-	"sfbYVu1u6+3OfrCaVm9ayjIDy/1MSr+F5nUINQnwToAup76+ntsBl/npTj1bSbadjt0dZGIr06sXk1qi",
-	"bVtFC9E8neh6AdzjNFNhOhgNRoPzEKn/vj3TQU5xTywlcCXov3+en/3w4V/j8cD88Kz6k2n//MfnP37T",
-	"ppH11HanXtZS7M3A075W692qNYV9domy6GY85wmaEkjiTk+6dRHayWrbYrwYvByce+q/VenqKAVRzolc",
-	"agsx1jjBgkTFKVHzQP1J0X0uZWbOloROWctMWJQryoU7CeHVr9c36Kd3l/qMd9O2cVwLRIQ5VCnzJ1QC",
-	"x5FUrvSOyHmj2wBdqqBCBIqrGEK9ceZMSCVOAF/oWKeCTz5JSNSQE6Ily3UAi+aYzgARqcLukuUcsTtq",
-	"RU11qztMpYvJGScLLJvTUeRTEqlX7VWnMoIwcEcTtbjngxfKYFgGFGckuAi+1R/p9Z7rlRoa3Scgtdcr",
-	"js6XsR5HfX7FmPyVxhkjVIXYWlXj5fl3XW67aDfszIBpA5iBbKs3SYHyzCgd0zgBXngvzphEz4bPEVhQ",
-	"6rSsOT7wBfAxvZyiuUwTtVAcPuUg1EHlGRnAAE05SxFGdzBBE87uBPDnZmUXBO6Aqy72XUiIQ8TkHPgd",
-	"EVDzzIYxWCuAWOm8rrZr9fkmrcXl8fNJpz3VqfteDpUyg4uHZs5FzRG5mdm8Sp6mmC/dw3KJpqW1mnXS",
-	"ybCMCdm0u3dMyBNbXZa3jZufdthVGDhmKIYPugy52r7/ytNl9bsWf7aRWVPFr74SoalptWYcfQyqWVgV",
-	"iar1zS0VpeijWrWWDz88kmO4Aplzu90ziMiURHbWa8WctqDRsVX/EQoO25VZIh62v4fk07H13S+zpNp9",
-	"/sziZd1ZNVyBUo5tjSYsXqI0Vz+BSX3qvV6zj9H5+Xb7WK87rsLg5flL736NCu8qDL7bYdx6rb7u3d5A",
-	"mRucLCt2oeM0nikDcnXT4MNGT/e17u8uF/x16qMtNgztgePMvQqkH1SOOP7Ro340evKurhVO48jm8j+1",
-	"ANCJtj7/vWFXxaw2P32soPgaZDQH0dCRjZCmilBS4ZKI1QKnPg6NqT0//L8oIimmsUtTCISpKSotAD37",
-	"m2TPTY7BVTgRNun2325u3lWY4aaw21vmZ7DMz8QmdiUAHUX9kges5UnxDPSrAVMV9gfHjPddW6yI/XaT",
-	"FBYQ+MT83va/DK+8hcr0y/wlLHMrQ3uw4dKfif2HyHn5nYl/miW4XHL5rroevQVY+YrEftCK74l0fPwF",
-	"ZBx6UziOKfS5kS88N9JvlCfrM7dQn37lnujKbWYzJ8s89fZwtJDX0/SvNEfW76F+D/XZvJNm85Siw/oN",
-	"COExUnz91u237pNKRvYG2Rvk6dOm5kvV248M5nvCv8zBGtHjpvcab5DO619bbmVoGyB7BcW175t7B8NG",
-	"xqUB1mVazOt2WxItp9V8l0s65ajK7vSrmt4nVf3y4/sXwSOfSPQ7rc7kKl9HqaSV64cQtdnRmOp3WWuH",
-	"iI1niHJ2a15+CwMs72jyoIuNa0t9+qzfzurRp+3KZo9u5d0xPmMUd1l7NC4vJPRsXFwa6NG+cSWVR5/6",
-	"vX9ey1C/1Nejy9qNTh49Wm9R8plN/VZAzx7+rduugN2l205dimuWdgW2S6/qHaS+41SvWfUzy8rFYz6r",
-	"v3bN1BMoo9TvIdk7+grruO179DVC6vy22Lv8cbrAtOWscKqBi9g8fND/Kc+22jVOq6OLvThv67mlFjrN",
-	"NWDtnLuAszfdviwkrDoffHiCFMPVto/CMv7BaxP2jKhnRD0j6hlRz4hOwIgcF6qFHOWyDyVHPRvYndf1",
-	"OqtT0sVon4TR6LMmjFwKfNTB68a0JXm0F6kb9amjnih1VZf3qCvv3OXINeyTEMDa3yb7qghjy9+Z81Nx",
-	"y99J6/lpz0+7Auf6/akHMNT3o0dI240+V9puFJyQIx2QuBv1tPMEVE//+Yj2JN5+bK9P4fXMtGemPTPt",
-	"mWnPTHtm+kSY6anSpz0n24Nf9zqrHA30RaB84TSQ88Re8ykuhsU1yAMh8QwG7m8LETbUW72jca3Zh9X/",
-	"AgAA//9NQMEQeoAAAA==",
+	"H4sIAAAAAAAC/+xdW4/btrP/KoROgZPgaO2NmxbovhRt06QLtDnBXnIe6hyAlsY2G4lUSMq77sLf/Q/e",
+	"dLEkm75tNolekl2LHP5mOBz+OCNzH4KIpRmjQKUILh6CDHOcggSuf8M8mr9Tn6hfYhARJ5kkjAYXwW8s",
+	"SSBSvyA2RQJUUyQkJ3QmkGRoShIJHAmJo48CTZZIzoFwpJoRCZHMOYggDIiS9SkHvgzCgOIUggs9ahAG",
+	"IppDitXI33GYBhfBfw1LrEPzVAx/qQlcrcIAS8nJJJfwFqcgjggfKXxCtR/TGKaEQoymHOBsyniKimE7",
+	"1arhqilIJKTa4HKZqaYGSLAK3QeYc7zU2kUsTTGN33CWZ+K4c5NxEEAlskOgMZ3pUTr0qSHxnq/far2U",
+	"RjFMcZ7IDl1+ZSwBTJuwyVTBXiLMAVkRiHFEmezAaxt5I31l2xuMWcKWKVB5HbEMTmT4cpQxFXqcTlXq",
+	"cHbQaa2jVY5DhCXEh82Bk7JtGly7XVC7LgZvAa4D8HXV8p3LudIHSbjvBlyK9kdc9tGQicgSvFQr/xDI",
+	"hCMrycSiLsTlaP6IK30U4hmRV5AyE60OxDwjEnEtTMPuQF0b0Rv3m1qvBvJTxX/1a6mW8FFJ7KeTqCt1",
+	"VIVury7302cPXSp6LIg4cO0WTmVEbYJbtNgBr+1jAV/nk1eEHwhXYj4DiUQ+iQmHSDK+RGPKdAC1umRM",
+	"EPV5tzYGyS662B5Wk1ueHMHqOU82OMgtT7wBqrYKGok63eGGzWYJIEYR0IjFCl3EqFTbZYaF0LtIGxIl",
+	"0hvHZWRnW/W65eRAIykpKOdkA7Rb/dQfnWqvACaYznI8OzQiZ5zNOE5T1cqJ7EBbeewH90/XweAV8i8W",
+	"kynpZBdbMDOOBE6zBCrwlVSUWrEoxrIbfDn8DgpUOmklCP14os2kCAFqDCRYzqPO6FvA8Nek6OHUODJz",
+	"1ajHdDvu3TAbvCm+v9Yfvge+YcO4mQNK8T1J8xTFsJiSBJARhhamYweudfneEOu9LFR/kNqI27HtiqqG",
+	"h1Bv0xG6h+nW5B9iOkL9QXqZrhC4l+no4Xx3A8mlu3DbgtJmnP0DkbxZZkcI/EoS0nmFdoiVwbyRvqv0",
+	"sYAXJIaDSJOdbCeqG6177A3VdFA4OdjQddywOKZOsGrRGRiL0b3BXxU9FHohMZfArfFPuTvZkZz7dCm0",
+	"Bsg/Kqz108rlWcb4USjrAiiy4hR57QJfDLgzf5V4dmQPUhI7cNpHe2QPjcNnjAoQBqkO+b9zzviVfaA+",
+	"twRbZ4CzLCERVviH/wil0UNl5IyzDLgkRhwoOU0cYXB/NmNnFr0eLDDOK3Oxrfm1abUqlWET5SMm01sB",
+	"t8Rp8oTA1dNUwUXwGpMEYjXj6hho0k/a+oNAt9U/v2XyNctpfITJeGTzntJgU0LjLovtZanNmTst18MA",
+	"flIael3nUQRCTPMEKQNq6YMxHdNrvd05GmaV0brOASdyfgSnSEEIdTLbMk1/2WYmYHzKCYc4uPi76P7h",
+	"UG85HQ5/c/+hjYqM42ozExrD/dEd6lJJNbT3QKeqS/LXVPerOVQKcs7it0z+kiTsDuLetfZxrb+0FVEu",
+	"IEZEIMqkYxkQD4IGP/Mw8r8kq+s2ZTzFMrgIJoRiTQLW9vgd3OC1CiuTpQTNO2J2RxOGDdDF6HJv39dW",
+	"daj0pwPro2H57Iykyi6mwiznJlM4zyeDiKVDG/KGHGZESL48s1Yc6gU5nAFVajBuF4JRerNPfBZQ/lPx",
+	"foTWF+XKMTrtxfWqdoNU/q/+AScoIUIqXplxpkZiawV2JOe4Rjacg4oQQZrJpREg8tkMhGxpHmGKJmBc",
+	"nFGE6bI2gGKojnzWEVYVsIW2icYDNQHuHAo0T9Xyw2n848sgDDBP9f9ZFv34MtHn0O9/Or+vLMsukhsG",
+	"9QpzA9mf1mSuym1q3MgV9Al1yleVc/gmOUniIAx4TtVaBCEDNemTfBa4IvF2jGGQU/Iph0sjXfIcVmHg",
+	"ys0NwK8TPENTxosqt5sc55oIqPq3zIrY0SambBto4Wt1306zlKVlZErQxilMhVfNmrFRxUna7EQoBZ4w",
+	"lgVhwHJpf97bMkX5d5NxivJzu3067FIRti678tBYZrPYUifH/jokuoUgJM/NKmBThFGUsDw+o1iShbbt",
+	"HeMfRYYjQMpNY1hAwjI9MUAXhDOa6sgR1oLd4gVOsjkeDV4Vk7NbvMMZGS5Gw+zjTP0ohgUKMXSydbCq",
+	"1osbet4K4IgDjvEkMbmE3QxYL+o2xL+plcvWSsubhW3w/FmnVFF18R2K0V7eXSmQ7gjN1eF8kOlMRTNW",
+	"Vqudzdc+OKbRPEQSz0LEuI6YGsgUONCoy9i25NjM11RLn02lJFPbDMJi8wC6VNe9ITof0yW4omJod5lW",
+	"Ybec+MrLOQndlojR7dWfyioYcUjMolWrygVHmylrHbXC41uz3ZpioEo2fm2RPxajCYOiltfA+a6lgohs",
+	"ttAZrYgdbVaoVdmant+o8JkgaXLCRU2wVXBR9GpIfete4HAIXWnKM4XWvoJNxWrDjtox1h7rtT0evt05",
+	"wFbz9U0XXGZgSaWpFbTwxw6hJrPeCdAl69cdZTvgMvHdaWcrybbTpKCDpWylkPUqVcs23lYqQzRPJ7oQ",
+	"AffGOS+C0WA0OA+R+u/7M717KlKLpQSuBP3/3+dnP334n/F4YH54Vv3JtH/+8/Ofv2uzyHrOvNMua7n7",
+	"5o7WPlfr3arFin1WifLoJlHgCZoSSOLOEL11EtpZcNtkvBi8HJx72r/V6OqMBlHOiVxqDzHeOMGCRMXx",
+	"UxNM/UnRfS5lZg6thE5ZiyYsyhWXw51M8+r36xv0y7tLfXi8aVs4rgUiwpzWlPsTKoHjSKoYfUfkvNFt",
+	"gC7VbkUEiqsYQr1w5kxIJU4AX+hNVO1q+SQhUUNOiJYs1ztjNMd0BohItZ8vWc4Ru6NW1FS3usNUus0+",
+	"42ShQnsDlzIekXrWXnUaIwgDd+ZRk3s+eKEchmVAcUaCi+B7/ZGe77meqaGxfQJSR73iTH4Z63HU51eM",
+	"yd9pnDFC1d5dK5e8PP+hK2wX7YadqTXtADOQbYUsKVCeGaNjGifAi+jFGZPo2fA5AgtKHcP14QH4AviY",
+	"Xk7RXKaJmigOn3IQ6gT0jAxggKacpQijO5igCWd3AvhzM7MLAnfAVRf7pijEIWJyDvyOCKhFZkNFrBdA",
+	"rGxeN9u1+nyT1eLyXPuk86nqOH8vh8qYwcVDM5mjdEROM5uwydMU86V7WE7RtPRWM086y5YxIZt+944J",
+	"eWKvy/K2cfPTDrsKA0c5xfBB87bV9vVXHlur30T5u40lGypYfddCc95qMTr6GFTTu2onqhZOt5Sqoo9q",
+	"1lo+/PBIgeEKZM7tcs8gIlMSWa3XqkRtm0bHUv0iDBy2G7NEPGx/wcmnY+tLZWZKdfj8lcXLerBqhAJl",
+	"HNsaTVi8RGmufgKTU9VrveYfo/Pz7f6xXtBchcHL85fe/Rql41UY/LDDuPWXAOrR7Q2UScfJsuIXep/G",
+	"M+VAriAbfNgY6b7V9d0Vgr9Ne7TtDUN74Dhz7xjpB5Ujjv/uUT8aPflQ1wqncWRziaXaBtCJtq7/3rCr",
+	"Ylabnz7WpvgaZDQH0bCR3SFNeaKkwiURq22c+jg0pvb88N+i2EkxjV2aQiBMTbVqAejZvyR7bnIMrnSK",
+	"sMnj/3Fz867CDDdtu71nfgbP/ExsYlcC0PG2QMkD1hKweAb6nYOp2vYHx9zvu5ZYsffbRVJ4QOCz5/e+",
+	"/3VE5S1Upp/mr2GaWxnag90u/ZnY/xE5L7+M8aV5gsslly/B69FbgJXvXuwHrfgCSsfHX0HGoXeF47hC",
+	"nxv5ynMj/UJ5sjFzC/XpZ+6JztxmNnOyzFPvD0fb8nqa/o3myPo11K+hPpt30myeMnRYv1ohPEaKr1+6",
+	"/dJ9UsnI3iF7hzx92tR8W3v7kcF8Afm3OVgnetz0XuMN0nn9+9CtDG0DZK9Nce2L7N6bYSPj0gDrMi3m",
+	"dbstiZbTWr4rJJ1yVOV3+lVN75Oqfvnx/YvgkU8k+p1W53KV77lU0sr1Q4ha7GhM9bustUPExjNEqd1a",
+	"lN/CAMvLnzzoYuNSV58+63fXevRpu9Dao1t5KY3PGMVN3x6Ny+saPRsXVyp6tG/cdeXRp34rotc01K88",
+	"9uiydlWUR4/W65l8tKlfN+jZw7912wW5u3TbqUtxf9OuwHbpVb2h1Xec6iW0fm5ZudHMZ/bX7q/ycuP1",
+	"yzKfQO2lfivK3lu2sNHevnxfY7Eu2Iu9ayan2822HDBONXCxoQ8f9H8qHK523dzVecde47f1sFPbb82l",
+	"ZO1EvYCzN0e/LCSsOh98eIK8xBXEj0JNvuC5CXsa1dOonkb1NKqnUU+FRjkCVdunVJw/lFH1FGJ3Mtjb",
+	"rM5jF6N9UlOjz5qacsn2UQcZHNOWNNVeTHDUJ6l6dtVVx96jgr1zlyNXy0/CGmt/I+6bYpktf+/Pz8Qt",
+	"f6+uJ7U9qT0qqV2/N/YAWvt+9AgJwtHnShCOghMSqwNShKOeq56AH+o/m9GeLtyPIvbJwp7O9nS2p7M9",
+	"ne3pbE9nv2Q6e6pEbU/k9iDlvc0q5wl9uSlfOAvkPLFXl4qLYXFn9EBIPIOB+0NMhA31Yu9oXGv2YfWf",
+	"AAAA//+adPhkbIIAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/index/server/pkg/server/endpoint.gen.go
+++ b/index/server/pkg/server/endpoint.gen.go
@@ -1555,11 +1555,19 @@ func (siw *ServerInterfaceWrapper) ServeDevfileIndexV2(c *gin.Context) {
 		return
 	}
 
-	// ------------- Optional query parameter "lastModified" -------------
+	// ------------- Optional query parameter "minLastModified" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "lastModified", c.Request.URL.Query(), &params.LastModified)
+	err = runtime.BindQueryParameter("form", true, false, "minLastModified", c.Request.URL.Query(), &params.MinLastModified)
 	if err != nil {
-		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter lastModified: %s", err), http.StatusBadRequest)
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter minLastModified: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "maxLastModified" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "maxLastModified", c.Request.URL.Query(), &params.MaxLastModified)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter maxLastModified: %s", err), http.StatusBadRequest)
 		return
 	}
 
@@ -1868,11 +1876,19 @@ func (siw *ServerInterfaceWrapper) ServeDevfileIndexV2WithType(c *gin.Context) {
 		return
 	}
 
-	// ------------- Optional query parameter "lastModified" -------------
+	// ------------- Optional query parameter "minLastModified" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "lastModified", c.Request.URL.Query(), &params.LastModified)
+	err = runtime.BindQueryParameter("form", true, false, "minLastModified", c.Request.URL.Query(), &params.MinLastModified)
 	if err != nil {
-		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter lastModified: %s", err), http.StatusBadRequest)
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter minLastModified: %s", err), http.StatusBadRequest)
+		return
+	}
+
+	// ------------- Optional query parameter "maxLastModified" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "maxLastModified", c.Request.URL.Query(), &params.MaxLastModified)
+	if err != nil {
+		siw.ErrorHandler(c, fmt.Errorf("Invalid format for parameter maxLastModified: %s", err), http.StatusBadRequest)
 		return
 	}
 
@@ -2040,65 +2056,66 @@ func RegisterHandlersWithOptions(router *gin.Engine, si ServerInterface, options
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+xdW4/btrP/KoROgZPgaO2NmxbovhRt06QLtDnBXnIe6hyAlsY2G4lUSMq77sLf/Q/e",
-	"dLEkm75tNoleEq9NDn8zHA5/nJHphyBiacYoUCmCi4cgwxynIIHrvzCP5u/UO+qPGETESSYJo8FF8BtL",
-	"EojUH4hNkQDVFAnJCZ0JJBmakkQCR0Li6KNAkyWScyAcqWZEQiRzDiIIA6JkfcqBL4MwoDiF4EKPGoSB",
-	"iOaQYjXydxymwUXwX8MS69B8Koa/1ASuVmGApeRkkkt4i1MQR4SPFD6h2o9pDFNCIUZTDnA2ZTxFxbCd",
-	"atVw1RQkElJtcLnMVFMDJFiF7g3MOV5q7SKWppjGbzjLM3Hcuck4CKAS2SHQmM70KB361JB4z9dvtV5K",
-	"oximOE9khy6/MpYApk3YZKpgLxHmgKwIxDiiTHbgtY28kb6y7Q3GLGHLFKi8jlgGJzJ8OcqYCj1Opyp1",
-	"ODvotNbRKschwhLiw+bASdk2Da7dLqhdF4O3ANcB+Lpq+c7lXOmDJNx3Ay5F+yMu+2jIRGQJXqqVfwhk",
-	"wpGVZGJRF+JyNH/ElT4K8YzIK0iZiVYHYp4RibgWpmF3oK6N6I37Ta1XA/mp4r/6s1RL+Kgk9tNJ1JU6",
-	"qkK3V5f76bOHLhU9FkQcuHYLpzKiNsEtWuyA1/axgK/zySvCD4QrMZ+BRCKfxIRDJBlfojFlOoBaXTIm",
-	"iHq/WxuDZBddbA+ryS1PjmD1nCcbHOSWJ94AVVsFjUSd7nDDZrMEEKMIaMRihS5iVKrtMsNC6F2kDYkS",
-	"6Y3jMrKzrXrdcnKgkZQUlHOyAdqt/tQfnWqvACaYznI8OzQiZ5zNOE5T1cqJ7EBb+dgP7p+ug8Er5F8s",
-	"JlPSyS62YGYcCZxmCVTgK6kotWJRjGU3+HL4HRSodNJKEPrxRJtJEQLUGEiwnEed0beA4a9J0cOpcWTm",
-	"qlGP6Xbcu2E2eFN8f63ffA98w4ZxMweU4nuS5imKYTElCSAjDC1Mxw5c6/K9IdZ7Waj+ILURt2PbFVUN",
-	"D6HepiN0D9OtyT/EdIT6g/QyXSFwL9PRw/nuBpJLd+G2BaXNOPsHInmzzI4Q+JUkpPMK7RArg3kjfVfp",
-	"YwEvSAwHkSY72U5UN1r3sTdU00Hh5GBD13HD4pg6wapFZ2AsRvcGf1X0UOiFxFwCt8Y/5e5kR3Lu06XQ",
-	"GiD/qLDWTyuXZxnjR6GsC6DIilPktQt8MeDO/FXi2ZE9SEnswGk/2iN7aBw+Y1SAMEh1yP+dc8av7Afq",
-	"fUuwdQY4yxISYYV/+I9QGj1URs44y4BLYsSBktPEEQb3ZzN2ZtHrwQLjvDIX25pfm1arUhk2UT5iMr0V",
-	"cEucJk8IXD1NFVwErzFJIFYzro6BJv2krT8IdFv9+i2Tr1lO4yNMxiOb95QGmxIad1lsL0ttztxpuR4G",
-	"8JPS0Os6jyIQYponSBlQSx+M6Zhe6+3O0TCrjNZ1DjiR8yM4RQpCqJPZlmn6yzYzAeNTTjjEwcXfRfcP",
-	"h3rL6XD4m/sPbVRkHFebmdAY7o/uUJdKqqG9BzpVXZK/prpfzaFSkHMWv2XylyRhdxD3rrWPa/2lrYhy",
-	"ATEiAlEmHcuAeBA0+JmHkf8lWV23KeMplsFFMCEUaxKwtsfv4AavVViZLCVo3hGzO5owbIAuRpd7+762",
-	"qkOl3x1YHw3Lz85IquxiKsxybjKF83wyiFg6tCFvyGFGhOTLM2vFoV6QwxlQpQbjdiEYpTf7xGcB5T8V",
-	"70dofVGuHKPTXlyvajdI5f/qFzhBCRFS8cqMMzUSWyuwIznHNbLhHFSECNJMLo0Akc9mIGRL8whTNAHj",
-	"4owiTJe1ARRDdeSzjrCqgC20TTQeqAlw51CgeaqWH07jH18GYYB5qv/PsujHl4k+h37/0/l9ZVl2kdww",
-	"qFeYG8j+tCZzVW5T40auoE+oU76qnMM3yUkSB2HAc6rWIggZqEmf5LPAFYm3YwyDnJJPOVwa6ZLnsAoD",
-	"V25uAH6d4BmaMl5Uud3kONdEQNW/ZVbEjjYxZdtAC1+r+3aapSwtI1OCNk5hKrxq1oyNKk7SZidCKfCE",
-	"sSwIA5ZL+3pvyxTl303GKcrP7fbpsEtF2LrsyofGMpvFljo59tch0S0EIXluVgGbIoyihOXxGcWSLLRt",
-	"7xj/KDIcAVJuGsMCEpbpiQG6IJzRVEeOsBbsFi9wks3xaPCqmJzd4h3OyHAxGmYfZ+qlGBYoxNDJ1sGq",
-	"Wi9u6HkrgCMOOMaTxOQSdjNgvajbEP+mVi5bKy1vFrbB82edUkXVxXcoRnt5d6VAuiM0V4fzQaYzFc1Y",
-	"Wa12Nh/74JhG8xBJPAsR4zpiaiBT4ECjLmPbkmMzX1MtfTaVkkxtMwiLzQPoUl33huh8TJfgioqh3WVa",
-	"hd1y4isv5yR0WyJGt1d/KqtgxCExi1atKhccbaasddQKj2/NdmuKgSrZ+LVF/liMJgyKWl4D57uWCiKy",
-	"2UJntCJ2tFmhVmVren6jwmeCpMkJFzXBVsFF0ash9a17gMMhdKUpzxRa+wo2FasNO2rHWHus1/Z4+Hbn",
-	"AFvN1zddcJmBJZWmVtDCHzuEmsx6J0CXrF93lO2Ay8R3p52tJNtOk4IOlrKVQtarVC3beFupDNE8nehC",
-	"BNwb57wIRoPR4DxE6r/vz/TuqUgtlhK4EvT/f5+f/fThf8bjgXnxrPrKtH/+8/Ofv2uzyHrOvNMua7n7",
-	"5o7WPlfr3arFin1WifLoJlHgCZoSSOLOEL11EtpZcNtkvBi8HJx72r/V6OqMBlHOiVxqDzHeOMGCRMXx",
-	"UxNM/U7RfS5lZg6thE5ZiyYsyhWXw51M8+r36xv0y7tLfXi8aVs4rgUiwpzWlPsTKoHjSKoYfUfkvNFt",
-	"gC7VbkUEiqsYQr1w5kxIJU4AX+hNVO1q+SQhUUNOiJYs1ztjNMd0BohItZ8vWc4Ru6NW1FS3usNUus0+",
-	"42ShQnsDlzIekXrWXnUaIwgDd+ZRk3s+eKEchmVAcUaCi+B7/Zae77meqaGxfQJSR73iTH4Z63HU+1eM",
-	"yd9pnDFC1d5dK5e8PP+hK2wX7YadqTXtADOQbYUsKVCeGaNjGifAi+jFGZPo2fA5AgtKHcP14QH4AviY",
-	"Xk7RXKaJmigOn3IQ6gT0jAxggKacpQijO5igCWd3AvhzM7MLAnfAVRf7pCjEIWJyDvyOCKhFZkNFrBdA",
-	"rGxeN9u1en+T1eLyXPuk86nqOH8vh8qYwcVDM5mjdEROM5uwydMU86X7sJyiaemtZp50li1jQjb97h0T",
-	"8sRel+Vt4+anHXYVBo5yiuGD5m2r7euvPLZWv4nydxtLNlSw+qyF5rzVYnT0Maimd9VOVC2cbilVRR/V",
-	"rLW8+eGRAsMVyJzb5Z5BRKYkslqvVYnaNo2OpfpFGDhsN2aJeNj+gJNPx9aHysyU6vD5K4uX9WDVCAXK",
-	"OLY1mrB4idJcvQKTU9VrveYfo/Pz7f6xXtBchcHL85fe/Rql41UY/LDDuPWHAOrR7Q2UScfJsuIXep/G",
-	"M+VAriAbfNgY6b7V9d0Vgr9Ne7TtDUN74DhzzxjpDypHHP/do340evKhrhVO48jmEku1DaATbV3/vWFX",
-	"xaw2f/pYm+JrkNEcRMNGdoc05YmSCpdErLZx6uPQmNrzw3+LYifFNHZpCoEwNdWqBaBn/5LsuckxuNIp",
-	"wiaP/8fNzbsKM9y07fae+Rk88zOxiV0JQMfTAiUPWEvA4hnoZw6matsfHHO/71pixd5vF0nhAYHPnt/7",
-	"/tcRlbdQmX6av4ZpbmVoD3a79Gdi/0fkvPwyxpfmCS6XXD4Er0dvAVY+e7EftOILKB1vfwUZh94VjuMK",
-	"fW7kK8+N9AvlycbMLdSnn7knOnOb2czJMk+9Pxxty+tp+jeaI+vXUL+G+mzeSbN5ytBh/WqF8Bgpvn7p",
-	"9kv3SSUje4fsHfL0aVPzbe3tRwbzBeTf5mCd6HHTe40nSOf170O3MrQNkL02xbUvsntvho2MSwOsy7SY",
-	"x+22JFpOa/mukHTKUZXf6Uc1vU+q+uHH9y+CRz6R6GdanctVvudSSSvXDyFqsaMx1c+y1g4RG88QpXZr",
-	"UX4LAywvf/Kgi41LXX36rN9d69Gn7UJrj27lpTQ+YxQ3fXs0Lq9r9GxcXKno0b5x15VHn/qtiF7TUL/y",
-	"2KPL2lVRHj1ar2fy0aZ+3aBnD//WbRfk7tJtpy7F/U27AtulV/WGVt9xqpfQ+rll5UYzn9lfu7/qCZRR",
-	"6hec7L37Chu47XP0NULq4rbYu/xxuo1py1nhVAMXe/PwQf+nIttq131aHV3sjXxbzy21rdPcL9bOuQs4",
-	"e9Pty0LCqvODD0+QYrja9lFYxhc8N2HPiHpG1DOinhH1jOgEjMhxodqWo0L2oeSoZwO787reZnVKuhjt",
-	"kzAafdaEkUuBjzp43Zi2JI/2InWjPnXUE6Wu6vIedeWduxy5hn0SAlj75bZvijC2/Aqfn4lbfkWu56dP",
-	"lZ/6RI/1n7d5AqR2/TbXA2jt+9Ej5PpGnyvXNwpOSKwOyPaNeq56An6of8yiPfO3H0Xs8349ne3pbE9n",
-	"ezrb09mezn7JdPZUidqeyO1BynubVc4T+spRvnAWyHliLxQVF8PiJueBkHgGA/fzSIQN9WLvaFxr9mH1",
-	"nwAAAP//VPY9BAKCAAA=",
+	"H4sIAAAAAAAC/+xdbXPbNhL+KxheZy6eoyVbcTtTf+m0TZN6Js1l7Dj3IfLNQORKQkMCDADKVn367zd4",
+	"o0iRlKC3xE34JZElYPHsYoF9sEtBj0HE0oxRoFIEl49BhjlOQQLXf2EeTd+qd9QfMYiIk0wSRoPL4FeW",
+	"JBCpPxAbIwGqKRKSEzoRSDI0JokEjoTE0UeBRnMkp0A4Us2IhEjmHEQQBkTJ+pQDnwdhQHEKwaUeNQgD",
+	"EU0hxWrk7ziMg8vgH/0l1r75VPR/rghcLMIAS8nJKJfwBqcgDggfKXxCtR/SGMaEQozGHOB0zHiKimFb",
+	"1argqihIJKTa4HKeqaYGSLAI3RuYczzX2kUsTTGNX3GWZ+Kwc5NxEEAlskOgIZ3oUVr0qSDxnq9fK72U",
+	"RjGMcZ7IFl1+YSwBTOuwyVjBniPMAVkRiHFEmWzBaxt5I31h2xuMWcLmKVB5E7EMjmT45ShDKvQ4rapU",
+	"4Wyh00pHqxyHCEuI95sDJ2XTNLh226B2XQzeAlwL4Juy5VuXc6kPkvDQDngp2h/xso+GTESW4Lla+ftA",
+	"JhxZSWYvakO8HM0fcamPQjwh8hpSZnarPTFPiERcC9OwW1BXRvTG/arSq4b8WPu/+nOplvBRSeymk6gq",
+	"dVCFbq+vdtNnB11KesyI2HPtFk5lRK2DW7TYAq/tYwHf5KMXhO8JV2I+AYlEPooJh0gyPkdDyvQGanXJ",
+	"mCDq/XZtDJJtdLE9rCa3PDmA1XOerHGQW554A1RtFTQStbrDOzaZJIAYRUAjFit0EaNShcsMC6GjSBMS",
+	"JdIbx1VkZ1v1uuVkTyMpKSjnZA20W/2pPzrVXgFMMJ3keLLvjpxxNuE4TVUrJ7IFbeljP7ivXQeNl9CP",
+	"R9qHi9WjxkCC5Txq3bgKGP5aFD2cGgcmfRr1kG7GvR1mgzfFD6+xkH+wmIxJK697NwWU4geS5il6lmAJ",
+	"Qp6gBAuJUtsRxViCUgsb/IraCZxmSZu3rAy8hdOUOlkNbvRn74GviRZlFWKYjUkCyMhEM9OxHWhFvjfS",
+	"ai8L1R+kMeNGbNuiquAh1HfyCTWTD5gn5BDTXx16j+kn1Hv6rRLbTf+K/H2mn1B/kF7TXwjcafrp/oR9",
+	"DUun25DzgpNnnP0JkXw3zw4QuZQkpBMjzRBLg3kjfVvqYwHPSAx7sT472U5UO1r3sTdU00Hh5GADyGGD",
+	"05A6wapFa3gqRvcGf130UOiFxFwCt8Y/JkewIzn3aVNoBZD/rrDSTyuXZxnjB+HcM6DIilPsuw18MeDW",
+	"BFziyYE9SElswWk/2iH9aRw+Y1SAMEj1lv8b54xf2w/U+/aEoFPYWZaQCCv8/T+F0uixNHLGWQZcEiMO",
+	"lJw6jjB4OJ2wU4teDxYY55W52NT8xrRaLJVhI+UjJlVdAjfHafKEwFXzbMFl8BKTBGI14+oca/Jn2vq9",
+	"QLfVr98w+ZLlND7AZHxm8x7TYGNC4zaL7WSp9alHLdfDAH5Sanrd5FEEQozzBCkDaum9IR3SGx3uHA2z",
+	"ymhdp4ATOT2AU6QghDpabpimP2wzs2F8ygmHOLj8UHS/29dbjofD39y/a6Mi47jazITG8HBwh7pSUg3t",
+	"3dOpqpL8NdX9Kg6Vgpyy+A2TPycJu4e4c61dXOsPbUWUC4gREYgy6VgGxL2gxs88jPwXyaq6jRlPsQwu",
+	"gxGhWJOAlRi/hRu8VNvKaC5B846Y3dOEYQN0Nrja2fe1VR0q/W7P+mi4/OyUpMoupkQupybVOc1HvYil",
+	"fbvl9TlMiJB8fmqt2NcLsj8BqtRg3C4Eo/R6n/gioPyn4v0ArS7KhWN02ourZfkaqfy3foETlBAhFa/M",
+	"OFMjsZUnBJCc4grZcA4qQgRpJudGgMgnExCyoXmEKRqBcXFGEabzygCKoTryWUVYVsBWCkcaD1QEuHMo",
+	"0DxVyw+n8Q8XQRhgnur/syz64UKnS8TzH88eSsuyjeSGQbVEXkP22prMlelNkR65JxIIdcqXlXP4RjlJ",
+	"4iAMeE7VWgQhAzXpo3wSuCr3ZoxhkFPyKYcrI13yHBZh4OrlNcAvEzxBY8aLMr2bHOeaCKj6d5kVsaON",
+	"TN050MJXCtetZlnWxpGpoRunMCVqNWvGRiUnabIToRR4wlgWhAHLpX29s2WK+vU64xT182b7tNilJGxV",
+	"dulDY5n1Ypc6OfbXItEtBCF5blaBThFGCcvjU4olmWnb3jP+UWQ4AqTcNIYZJCzTEwN0Rjijqd45wspm",
+	"NzvHSTbFg96LYnK22+9wRvqzQT/7OFEvRb9AIfpOtt6sygXvmp63AjjigGM8SkwuYTsDVqvSNfGvKvW+",
+	"ldr4emFrPH/SKlWUXXyLarqXd5cqvFtCc4VEH2Q6U1HfK8vl2vpzKxzTaBoiiSchYlzvmBrIGDjQqM3Y",
+	"tmZaz9eUa7d1pSRTYQZhsX4AXWtsD4jOx3QNsSh52ijTKOyWE195OSehC4kY3V6/VlbBiENiFq1aVW5z",
+	"tJmyxlFLPL4x260pBipl41cW+ediNGFQFCNrON82lECRzRY6oxV7R5MVKjWLuud711Hgwby6DAZng4vT",
+	"s/PTs3PFHLCUwJWo/w6H8ePFYjg8fXb24fz0x7v/nX84Ox/cnZTe+XA+uPtwpl49/3B2fnfyXSPioqZZ",
+	"g/vGPdriVHeVR8/cXPPWYAqSa0J1y1g7bATNG+2brXfuciGg7tvzDCxbNUWIBmLaItSk7FsBuirAqgdu",
+	"BrzMqLfa2Uqy7TTbaKE/G7lptfzVwA+aanCI5ulIVzhKvt4b9M5CpP57fqrDctXntTP/azjsmRfPyq9M",
+	"+5OfTn5qdPPVZHyrXVaKAvVQ2TxXq93KVZBdVony6DoD4QkaE0ji1r1/4yQ00+umyTjvXfTOPO3faHR1",
+	"+IMo50TOtYcYbxxhQaLiXKuZq36n6D6VMjOnYULHrEETFuWKJOJWCnv928079PPbK30qfde0cFwLRIQ5",
+	"Bir3J1QCx5FUm/89kdNatx66UmGQCBSXMYR64UyZkEqcAD7T0VmFy3yUkKgmJ0RzluuQG00xnQAiUhGF",
+	"Ocs5YvfUihrrVveYSsciMk5mKmbUcCnjEaln7UWrMYIwcIcpNblnvXPlMCwDijMSXAbP9Vt6vqd6pvrG",
+	"9glIvesVh/2rWI+j3r9mTP5G44wRqkhBpQ5zcfZ927ZdtOu35uy0A0xANlXIpEB5ZoyOaZwAL3YvzphE",
+	"z/onCCwodb7XpxLgM+BDejVGU5kmaqI4fMpBqKPVM9KDHhpzliKM7mGERpzdC+AnZmZnBO6Bqy72GVqI",
+	"Q8TkFPg9EVDZmQ3HsV4AsbJ51Ww36v11VouXB+YnnagNAwkPsq+MGVw+1rNESkfkNLOZoDxNMZ+7D5dT",
+	"NF56q5knnb7LmJB1v3vLhDyy12V507j5cYddhIHjsqL/qAnhYvP6W56Hy9/R+dBEvw3HLD/Eocl0ucod",
+	"fQzKeWMVicoV2Q01sOijmrWGN+8+08ZwDTLndrlnEJExiazWK+WnpqDRslT/FgYOm425RNxvfnLKp2Pj",
+	"E3dmSvX2+QuL59XNqrYVKOPY1mjE4jlKc/UKTLJWr/WKfwzOzjb7x2qldBEGF2cX3v1qNelFGHy/xbjV",
+	"pwuqu9srWGYzR/OSX+g4jSfKgVylN7hbu9N9q+u7bQv+Nu3RFBv69sBx6h5e0h+Ujjj+0aN6NHryW10j",
+	"nNqRzWWsKgGgFW1V/51hl8Us1n/6uYLiS5DRFETNRjZCmrrHkgoviVglcOrj0JDa88M/RRFJMY1dmkIg",
+	"TE0ZbAbo2V8kOzE5BleTRdgUCH5/9+5tiRmuC7udZ34Bz/xCbGJbAtDyGMKSB6xkdvEE9MMMYxX2e4eM",
+	"921LrIj9dpEUHhD4xPzO97+OXXkDlemm+WuY5kaG9mjDpT8T+w+R0+W3PP5unuByycun6/XoDcCWD3Xs",
+	"Bq34ZkvL219BxqFzhcO4Qpcb+cpzI91CebJ75gbq083cE5259WzmaJmnzh8OFvI6mv6N5si6NdStoS6b",
+	"d9RsnjJ0WL2zITxEiq9but3SfVLJyM4hO4c8ftrUfA1885HBfLP51ylYJ/q86b3aE6TT6hetGxnaGshe",
+	"QXHlG/LewbCWcamBdZkW87jdhkTLcS3ftiUdc1Tld/pRTe+Tqn748f158JlPJPqZVudypS/QlNLK1UOI",
+	"WuxoSPWzrJVDxNozxFK7lV1+AwNc3irlQRdr19369Fm91dejT9NV3x7dlrfd+IxR3IHu0Xh5kaVn4+Ky",
+	"SY/2tUu0PPpU74v0mobqZdAeXVbuoPLo0Xjvk4821dskPXv4t266Onibblt1KS6G2hbYNr3Kd9f6jlO+",
+	"ntfPLUtXpfnM/srFWE+gjFK9OWXn6Cvsxm2fo68QUrdvi53LH8cLTBvOCscauIjN/Uf9n9rZFtvGaXV0",
+	"sVf9bTy3VEKnubismXMXcHam21eFhEXrB3dPkGK42vZBWMbfeG7CjhF1jKhjRB0j6hjRERiR40KVkKO2",
+	"7H3JUccGtud1nc2qlHQ22CVhNPiiCSOXAh+08LohbUge7UTqBl3qqCNKbdXlHerKW3c5cA37KASw8pt2",
+	"3xRhbPh9Qj8TN/y+XsdPnyo/9Vqm9R8h8VulDf2+PB9evWF2D0b8fvAZ0oSDL5UmHARH5GR7JAoHHc09",
+	"ArXUP7DRnDTcjV12KcOOCXdMuGPCHRPumHDHhL9RJnys9HDHAXfg853NSkcRfdEpnzkL5Dyx15iKy35x",
+	"MXVPSDyBnvu1J8L6er23NK40u1v8PwAA//+Y36ezkoMAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -551,6 +551,7 @@ func buildIndexAPIResponse(c *gin.Context, indexType string, wantV1Index bool, p
 		maxSchemaVersion := params.MaxSchemaVersion
 		minVersion := params.MinVersion
 		maxVersion := params.MaxVersion
+		lastModified := params.LastModified
 
 		if util.StrPtrIsSet(maxSchemaVersion) || util.StrPtrIsSet(minSchemaVersion) {
 			// check if schema version filters are in valid format.
@@ -613,6 +614,17 @@ func buildIndexAPIResponse(c *gin.Context, indexType string, wantV1Index bool, p
 				return
 			}
 		}
+
+		if util.StrPtrIsSet(lastModified) {
+			index, err = util.FilterLastModifiedDate(index, lastModified)
+			if err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{
+					"status": fmt.Sprintf("failed to apply last modified filter: %v", err),
+				})
+				return
+			}
+		}
+
 	}
 
 	// Filter the fields of the index

--- a/index/server/pkg/server/endpoint.go
+++ b/index/server/pkg/server/endpoint.go
@@ -551,7 +551,8 @@ func buildIndexAPIResponse(c *gin.Context, indexType string, wantV1Index bool, p
 		maxSchemaVersion := params.MaxSchemaVersion
 		minVersion := params.MinVersion
 		maxVersion := params.MaxVersion
-		lastModified := params.LastModified
+		minLastModified := params.MinLastModified
+		maxLastModified := params.MaxLastModified
 
 		if util.StrPtrIsSet(maxSchemaVersion) || util.StrPtrIsSet(minSchemaVersion) {
 			// check if schema version filters are in valid format.
@@ -615,8 +616,20 @@ func buildIndexAPIResponse(c *gin.Context, indexType string, wantV1Index bool, p
 			}
 		}
 
-		if util.StrPtrIsSet(lastModified) {
-			index, err = util.FilterLastModifiedDate(index, lastModified)
+		if util.StrPtrIsSet(minLastModified) || util.StrPtrIsSet(maxLastModified) {
+			if util.StrPtrIsSet(minLastModified) && util.IsInvalidLastModifiedDate(minLastModified) {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"status": fmt.Sprintf("minLastModified %s is not valid, format should be 'YYYY-MM-DD' and be a valid date. %v", *minLastModified, err),
+				})
+				return
+			}
+			if util.StrPtrIsSet(maxLastModified) && util.IsInvalidLastModifiedDate(maxLastModified) {
+				c.JSON(http.StatusBadRequest, gin.H{
+					"status": fmt.Sprintf("maxLastModified %s is not valid, format should be 'YYYY-MM-DD' and be a valid date. %v", *maxLastModified, err),
+				})
+				return
+			}
+			index, err = util.FilterLastModifiedDate(index, minLastModified, maxLastModified)
 			if err != nil {
 				c.JSON(http.StatusInternalServerError, gin.H{
 					"status": fmt.Sprintf("failed to apply last modified filter: %v", err),

--- a/index/server/pkg/server/types.gen.go
+++ b/index/server/pkg/server/types.gen.go
@@ -121,20 +121,23 @@ type IndexParams struct {
 	// Language Programming language of the devfile workspace
 	Language *Language `json:"language,omitempty"`
 
-	// LastModified Last modified date of a stack or sample
-	LastModified *LastModified `json:"lastModified,omitempty"`
-
 	// LinkNames Names of devfile links
 	LinkNames *LinkNames `json:"linkNames,omitempty"`
 
 	// Links List of devfile links
 	Links *Links `json:"links,omitempty"`
 
+	// MaxLastModified Last modified date of a stack or sample
+	MaxLastModified *LastModified `json:"maxLastModified,omitempty"`
+
 	// MaxSchemaVersion Devfile schema version number
 	MaxSchemaVersion *SchemaVersion `json:"maxSchemaVersion,omitempty"`
 
 	// MaxVersion Devfile registry entry version number
 	MaxVersion *Version `json:"maxVersion,omitempty"`
+
+	// MinLastModified Last modified date of a stack or sample
+	MinLastModified *LastModified `json:"minLastModified,omitempty"`
 
 	// MinSchemaVersion Devfile schema version number
 	MinSchemaVersion *SchemaVersion `json:"minSchemaVersion,omitempty"`
@@ -257,20 +260,23 @@ type IconUriParam = IconUri
 // LanguageParam Programming language of the devfile workspace
 type LanguageParam = Language
 
-// LastModifiedParam Last modified date of a stack or sample
-type LastModifiedParam = LastModified
-
 // LinkNamesParam Names of devfile links
 type LinkNamesParam = LinkNames
 
 // LinksParam List of devfile links
 type LinksParam = Links
 
+// MaxLastModifiedParam Last modified date of a stack or sample
+type MaxLastModifiedParam = LastModified
+
 // MaxSchemaVersionParam Devfile schema version number
 type MaxSchemaVersionParam = SchemaVersion
 
 // MaxVersionParam Devfile registry entry version number
 type MaxVersionParam = Version
+
+// MinLastModifiedParam Last modified date of a stack or sample
+type MinLastModifiedParam = LastModified
 
 // MinSchemaVersionParam Devfile schema version number
 type MinSchemaVersionParam = SchemaVersion
@@ -627,8 +633,11 @@ type ServeDevfileIndexV2Params struct {
 	// SupportUrl Search string to filter stacks by their given support url
 	SupportUrl *SupportUrlParam `form:"supportUrl,omitempty" json:"supportUrl,omitempty"`
 
-	// LastModified Search string to filter stacks or samples by their last modified date
-	LastModified *LastModifiedParam `form:"lastModified,omitempty" json:"lastModified,omitempty"`
+	// MinLastModified The minimum (earliest) last modified date of a stack or sample
+	MinLastModified *MinLastModifiedParam `form:"minLastModified,omitempty" json:"minLastModified,omitempty"`
+
+	// MaxLastModified The maximum (latest) last modified date of a stack or sample
+	MaxLastModified *MaxLastModifiedParam `form:"maxLastModified,omitempty" json:"maxLastModified,omitempty"`
 }
 
 // ServeDevfileIndexV2WithTypeParams defines parameters for ServeDevfileIndexV2WithType.
@@ -733,6 +742,9 @@ type ServeDevfileIndexV2WithTypeParams struct {
 	// SupportUrl Search string to filter stacks by their given support url
 	SupportUrl *SupportUrlParam `form:"supportUrl,omitempty" json:"supportUrl,omitempty"`
 
-	// LastModified Search string to filter stacks or samples by their last modified date
-	LastModified *LastModifiedParam `form:"lastModified,omitempty" json:"lastModified,omitempty"`
+	// MinLastModified The minimum (earliest) last modified date of a stack or sample
+	MinLastModified *MinLastModifiedParam `form:"minLastModified,omitempty" json:"minLastModified,omitempty"`
+
+	// MaxLastModified The maximum (latest) last modified date of a stack or sample
+	MaxLastModified *MaxLastModifiedParam `form:"maxLastModified,omitempty" json:"maxLastModified,omitempty"`
 }

--- a/index/server/pkg/server/types.gen.go
+++ b/index/server/pkg/server/types.gen.go
@@ -443,9 +443,6 @@ type ServeDevfileIndexV1Params struct {
 
 	// SupportUrl Search string to filter stacks by their given support url
 	SupportUrl *SupportUrlParam `form:"supportUrl,omitempty" json:"supportUrl,omitempty"`
-
-	// LastModified Search string to filter stacks or samples by their last modified date
-	LastModified *LastModifiedParam `form:"lastModified,omitempty" json:"lastModified,omitempty"`
 }
 
 // ServeDevfileIndexV1WithTypeParams defines parameters for ServeDevfileIndexV1WithType.
@@ -526,9 +523,6 @@ type ServeDevfileIndexV1WithTypeParams struct {
 
 	// SupportUrl Search string to filter stacks by their given support url
 	SupportUrl *SupportUrlParam `form:"supportUrl,omitempty" json:"supportUrl,omitempty"`
-
-	// LastModified Search string to filter stacks or samples by their last modified date
-	LastModified *LastModifiedParam `form:"lastModified,omitempty" json:"lastModified,omitempty"`
 }
 
 // ServeDevfileIndexV2Params defines parameters for ServeDevfileIndexV2.

--- a/index/server/pkg/server/types.gen.go
+++ b/index/server/pkg/server/types.gen.go
@@ -121,6 +121,9 @@ type IndexParams struct {
 	// Language Programming language of the devfile workspace
 	Language *Language `json:"language,omitempty"`
 
+	// LastModified Last modified date of a stack or sample
+	LastModified *LastModified `json:"lastModified,omitempty"`
+
 	// LinkNames Names of devfile links
 	LinkNames *LinkNames `json:"linkNames,omitempty"`
 
@@ -166,6 +169,9 @@ type IndexSchema = schema.Schema
 
 // Language Programming language of the devfile workspace
 type Language = string
+
+// LastModified Last modified date of a stack or sample
+type LastModified = string
 
 // LinkNames Names of devfile links
 type LinkNames = []string
@@ -250,6 +256,9 @@ type IconUriParam = IconUri
 
 // LanguageParam Programming language of the devfile workspace
 type LanguageParam = Language
+
+// LastModifiedParam Last modified date of a stack or sample
+type LastModifiedParam = LastModified
 
 // LinkNamesParam Names of devfile links
 type LinkNamesParam = LinkNames
@@ -434,6 +443,9 @@ type ServeDevfileIndexV1Params struct {
 
 	// SupportUrl Search string to filter stacks by their given support url
 	SupportUrl *SupportUrlParam `form:"supportUrl,omitempty" json:"supportUrl,omitempty"`
+
+	// LastModified Search string to filter stacks or samples by their last modified date
+	LastModified *LastModifiedParam `form:"lastModified,omitempty" json:"lastModified,omitempty"`
 }
 
 // ServeDevfileIndexV1WithTypeParams defines parameters for ServeDevfileIndexV1WithType.
@@ -514,6 +526,9 @@ type ServeDevfileIndexV1WithTypeParams struct {
 
 	// SupportUrl Search string to filter stacks by their given support url
 	SupportUrl *SupportUrlParam `form:"supportUrl,omitempty" json:"supportUrl,omitempty"`
+
+	// LastModified Search string to filter stacks or samples by their last modified date
+	LastModified *LastModifiedParam `form:"lastModified,omitempty" json:"lastModified,omitempty"`
 }
 
 // ServeDevfileIndexV2Params defines parameters for ServeDevfileIndexV2.
@@ -617,6 +632,9 @@ type ServeDevfileIndexV2Params struct {
 
 	// SupportUrl Search string to filter stacks by their given support url
 	SupportUrl *SupportUrlParam `form:"supportUrl,omitempty" json:"supportUrl,omitempty"`
+
+	// LastModified Search string to filter stacks or samples by their last modified date
+	LastModified *LastModifiedParam `form:"lastModified,omitempty" json:"lastModified,omitempty"`
 }
 
 // ServeDevfileIndexV2WithTypeParams defines parameters for ServeDevfileIndexV2WithType.
@@ -720,4 +738,7 @@ type ServeDevfileIndexV2WithTypeParams struct {
 
 	// SupportUrl Search string to filter stacks by their given support url
 	SupportUrl *SupportUrlParam `form:"supportUrl,omitempty" json:"supportUrl,omitempty"`
+
+	// LastModified Search string to filter stacks or samples by their last modified date
+	LastModified *LastModifiedParam `form:"lastModified,omitempty" json:"lastModified,omitempty"`
 }

--- a/index/server/pkg/server/types.go
+++ b/index/server/pkg/server/types.go
@@ -45,6 +45,7 @@ func (params *ServeDevfileIndexV2Params) toIndexParams() IndexParams {
 		GitRevision:      params.GitRevision,
 		Provider:         params.Provider,
 		SupportUrl:       params.SupportUrl,
+		LastModified:     params.LastModified,
 	}
 }
 
@@ -80,6 +81,7 @@ func (params *ServeDevfileIndexV2WithTypeParams) toIndexParams() IndexParams {
 		GitRevision:      params.GitRevision,
 		Provider:         params.Provider,
 		SupportUrl:       params.SupportUrl,
+		LastModified:     params.LastModified,
 	}
 }
 

--- a/index/server/pkg/server/types.go
+++ b/index/server/pkg/server/types.go
@@ -45,7 +45,8 @@ func (params *ServeDevfileIndexV2Params) toIndexParams() IndexParams {
 		GitRevision:      params.GitRevision,
 		Provider:         params.Provider,
 		SupportUrl:       params.SupportUrl,
-		LastModified:     params.LastModified,
+		MinLastModified:  params.MinLastModified,
+		MaxLastModified:  params.MaxLastModified,
 	}
 }
 
@@ -81,7 +82,8 @@ func (params *ServeDevfileIndexV2WithTypeParams) toIndexParams() IndexParams {
 		GitRevision:      params.GitRevision,
 		Provider:         params.Provider,
 		SupportUrl:       params.SupportUrl,
-		LastModified:     params.LastModified,
+		MinLastModified:  params.MinLastModified,
+		MaxLastModified:  params.MaxLastModified,
 	}
 }
 

--- a/index/server/pkg/util/filter.go
+++ b/index/server/pkg/util/filter.go
@@ -66,6 +66,8 @@ const (
 	ParamProvider = "provider"
 	// Parameter 'supportUrl'
 	ParamSupportUrl = "supportUrl"
+	// Parameter 'lastModified'
+	ParamLastModified = "lastModified"
 
 	/* Array Parameter Names */
 
@@ -793,4 +795,29 @@ func FilterDevfileStrArrayField(index []indexSchema.Schema, paramName string, re
 		Name:  filterName,
 		Index: filterDevfileArrayFuzzy(index, requestedValues, options),
 	}
+}
+
+// FilterLastModifiedDate filters based on the last modified date of a stack or sample
+func FilterLastModifiedDate(index []indexSchema.Schema, lastModified *string) ([]indexSchema.Schema, error) {
+	filteredIndex := deepcopy.Copy(index).([]indexSchema.Schema)
+	for i := 0; i < len(filteredIndex); i++ {
+		for versionIndex := 0; versionIndex < len(filteredIndex[i].Versions); versionIndex++ {
+			currentLastModifiedDate := filteredIndex[i].Versions[versionIndex].LastModified
+			matchedLastModified := false
+			if StrPtrIsSet(lastModified) && (*lastModified == currentLastModifiedDate) {
+				matchedLastModified = true
+			}
+
+			if !matchedLastModified {
+				// if version is not in requested range, filter it out
+				filterOut(&filteredIndex[i].Versions, &versionIndex)
+			}
+		}
+		if len(filteredIndex[i].Versions) == 0 {
+			// if versions list is empty after filter, remove this index
+			filterOut(&filteredIndex, &i)
+		}
+	}
+
+	return filteredIndex, nil
 }

--- a/index/server/pkg/util/filter_test.go
+++ b/index/server/pkg/util/filter_test.go
@@ -3666,3 +3666,160 @@ func TestAndFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestFilterLastModifiedDate(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		index            []indexSchema.Schema
+		lastModifiedDate string
+		wantIndex        []indexSchema.Schema
+	}{
+		{
+			name: "Single match",
+			index: []indexSchema.Schema{
+				{
+					Name: "devfileA",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2020-01-01",
+						},
+						{
+							Version:      "1.1.0",
+							LastModified: "2021-02-02",
+						},
+						{
+							Version:      "1.2.0",
+							LastModified: "2021-02-02",
+						},
+					},
+				},
+				{
+					Name: "devfileB",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2021-02-02",
+						},
+					},
+				},
+			},
+			lastModifiedDate: "2020-01-01",
+			wantIndex: []indexSchema.Schema{
+				{
+					Name: "devfileA",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2020-01-01",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple Matches",
+			index: []indexSchema.Schema{
+				{
+					Name: "devfileA",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2020-01-01",
+						},
+						{
+							Version:      "1.1.0",
+							LastModified: "2021-02-02",
+						},
+						{
+							Version:      "1.2.0",
+							LastModified: "2021-02-02",
+						},
+					},
+				},
+				{
+					Name: "devfileB",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2021-02-02",
+						},
+					},
+				},
+			},
+			lastModifiedDate: "2021-02-02",
+			wantIndex: []indexSchema.Schema{
+				{
+					Name: "devfileA",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.1.0",
+							LastModified: "2021-02-02",
+						},
+						{
+							Version:      "1.2.0",
+							LastModified: "2021-02-02",
+						},
+					},
+				},
+				{
+					Name: "devfileB",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2021-02-02",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "No Match",
+			index: []indexSchema.Schema{
+				{
+					Name: "devfileA",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2020-01-01",
+						},
+						{
+							Version:      "1.1.0",
+							LastModified: "2021-02-02",
+						},
+						{
+							Version:      "1.2.0",
+							LastModified: "2021-02-02",
+						},
+					},
+				},
+				{
+					Name: "devfileB",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2021-02-02",
+						},
+					},
+				},
+			},
+			lastModifiedDate: "2024-04-04",
+			wantIndex:        []indexSchema.Schema{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			gotIndex, gotErr := FilterLastModifiedDate(test.index, &test.lastModifiedDate)
+			if gotErr != nil {
+				if gotIndex != nil {
+					t.Errorf("Unexpected non-nil index on error: %v", gotIndex)
+				}
+				t.Errorf("Unexpected error: %v", gotErr)
+			} else if !reflect.DeepEqual(gotIndex, test.wantIndex) {
+				t.Errorf("Got: %v, Expected: %v", gotIndex, test.wantIndex)
+			}
+		})
+	}
+}

--- a/index/server/pkg/util/filter_test.go
+++ b/index/server/pkg/util/filter_test.go
@@ -3668,30 +3668,42 @@ func TestAndFilter(t *testing.T) {
 }
 
 func TestFilterLastModifiedDate(t *testing.T) {
+	validMin := "2023-11-08"
+	validMax := "2024-04-08"
+	validMid := "2024-02-25"
+	invalidMin := "2025-04-04"
+	invalidMax := "2020-01-01"
+	var nilPtr *string
+	var validMinPtr *string = &validMin
+	var validMaxPtr *string = &validMax
+	var validMidPtr *string = &validMid
+	var invalidMinPtr *string = &invalidMin
+	var invalidMaxPtr *string = &invalidMax
 
 	tests := []struct {
-		name             string
-		index            []indexSchema.Schema
-		lastModifiedDate string
-		wantIndex        []indexSchema.Schema
+		name            string
+		index           []indexSchema.Schema
+		minLastModified *string
+		maxLastModified *string
+		wantIndex       []indexSchema.Schema
 	}{
 		{
-			name: "Single match",
+			name: "Match with minLastModified",
 			index: []indexSchema.Schema{
 				{
 					Name: "devfileA",
 					Versions: []indexSchema.Version{
 						{
 							Version:      "1.0.0",
-							LastModified: "2020-01-01",
+							LastModified: "2023-11-08T12:54:08+00:00",
 						},
 						{
 							Version:      "1.1.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 						{
 							Version:      "1.2.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 					},
 				},
@@ -3700,41 +3712,59 @@ func TestFilterLastModifiedDate(t *testing.T) {
 					Versions: []indexSchema.Version{
 						{
 							Version:      "1.0.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 					},
 				},
 			},
-			lastModifiedDate: "2020-01-01",
+			minLastModified: validMinPtr,
+			maxLastModified: nilPtr,
 			wantIndex: []indexSchema.Schema{
 				{
 					Name: "devfileA",
 					Versions: []indexSchema.Version{
 						{
 							Version:      "1.0.0",
-							LastModified: "2020-01-01",
+							LastModified: "2023-11-08T12:54:08+00:00",
+						},
+						{
+							Version:      "1.1.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+						{
+							Version:      "1.2.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+					},
+				},
+				{
+					Name: "devfileB",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "Multiple Matches",
+			name: "Match with maxLastModified",
 			index: []indexSchema.Schema{
 				{
 					Name: "devfileA",
 					Versions: []indexSchema.Version{
 						{
 							Version:      "1.0.0",
-							LastModified: "2020-01-01",
+							LastModified: "2023-11-08T12:54:08+00:00",
 						},
 						{
 							Version:      "1.1.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 						{
 							Version:      "1.2.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 					},
 				},
@@ -3743,23 +3773,28 @@ func TestFilterLastModifiedDate(t *testing.T) {
 					Versions: []indexSchema.Version{
 						{
 							Version:      "1.0.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 					},
 				},
 			},
-			lastModifiedDate: "2021-02-02",
+			minLastModified: nilPtr,
+			maxLastModified: validMaxPtr,
 			wantIndex: []indexSchema.Schema{
 				{
 					Name: "devfileA",
 					Versions: []indexSchema.Version{
 						{
+							Version:      "1.0.0",
+							LastModified: "2023-11-08T12:54:08+00:00",
+						},
+						{
 							Version:      "1.1.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 						{
 							Version:      "1.2.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 					},
 				},
@@ -3768,7 +3803,72 @@ func TestFilterLastModifiedDate(t *testing.T) {
 					Versions: []indexSchema.Version{
 						{
 							Version:      "1.0.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Match with minLastModified and maxLastModified",
+			index: []indexSchema.Schema{
+				{
+					Name: "devfileA",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2023-11-08T12:54:08+00:00",
+						},
+						{
+							Version:      "1.1.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+						{
+							Version:      "1.2.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+						{
+							Version:      "1.3.0",
+							LastModified: "2024-01-23T11:51:08+00:00",
+						},
+					},
+				},
+				{
+					Name: "devfileB",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+						{
+							Version:      "1.0.0",
+							LastModified: "2023-12-18T11:51:08+00:00",
+						},
+					},
+				},
+			},
+			minLastModified: validMinPtr,
+			maxLastModified: validMidPtr,
+			wantIndex: []indexSchema.Schema{
+				{
+					Name: "devfileA",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2023-11-08T12:54:08+00:00",
+						},
+						{
+							Version:      "1.3.0",
+							LastModified: "2024-01-23T11:51:08+00:00",
+						},
+					},
+				},
+				{
+					Name: "devfileB",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2023-12-18T11:51:08+00:00",
 						},
 					},
 				},
@@ -3782,15 +3882,15 @@ func TestFilterLastModifiedDate(t *testing.T) {
 					Versions: []indexSchema.Version{
 						{
 							Version:      "1.0.0",
-							LastModified: "2020-01-01",
+							LastModified: "2023-11-08T12:54:08+00:00",
 						},
 						{
 							Version:      "1.1.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 						{
 							Version:      "1.2.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 					},
 				},
@@ -3799,19 +3899,54 @@ func TestFilterLastModifiedDate(t *testing.T) {
 					Versions: []indexSchema.Version{
 						{
 							Version:      "1.0.0",
-							LastModified: "2021-02-02",
+							LastModified: "2024-04-08T11:51:08+00:00",
 						},
 					},
 				},
 			},
-			lastModifiedDate: "2024-04-04",
-			wantIndex:        []indexSchema.Schema{},
+			minLastModified: invalidMinPtr,
+			maxLastModified: invalidMaxPtr,
+			wantIndex:       []indexSchema.Schema{},
+		},
+		{
+			name: "Unset Pointers",
+			index: []indexSchema.Schema{
+				{
+					Name: "devfileA",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2023-11-08T12:54:08+00:00",
+						},
+						{
+							Version:      "1.1.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+						{
+							Version:      "1.2.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+					},
+				},
+				{
+					Name: "devfileB",
+					Versions: []indexSchema.Version{
+						{
+							Version:      "1.0.0",
+							LastModified: "2024-04-08T11:51:08+00:00",
+						},
+					},
+				},
+			},
+			minLastModified: nilPtr,
+			maxLastModified: nilPtr,
+			wantIndex:       []indexSchema.Schema{},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			gotIndex, gotErr := FilterLastModifiedDate(test.index, &test.lastModifiedDate)
+			gotIndex, gotErr := FilterLastModifiedDate(test.index, test.minLastModified, test.maxLastModified)
 			if gotErr != nil {
 				if gotIndex != nil {
 					t.Errorf("Unexpected non-nil index on error: %v", gotIndex)

--- a/index/server/vendor/github.com/devfile/registry-support/index/generator/library/library.go
+++ b/index/server/vendor/github.com/devfile/registry-support/index/generator/library/library.go
@@ -737,7 +737,10 @@ func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]sche
 
 	for i := range index {
 		for j := range index[i].Versions {
-			updateSchemaLastModified(&index[i], j, lastModifiedEntriesMap[index[i].Name][index[i].Versions[j].Version])
+			schemaItem := index[i] // a stack or sample
+			versions := schemaItem.Versions[j]
+			versionNum := versions.Version
+			updateSchemaLastModified(&schemaItem, j, lastModifiedEntriesMap[schemaItem.Name][versionNum])
 		}
 	}
 

--- a/index/server/vendor/github.com/devfile/registry-support/index/generator/library/library.go
+++ b/index/server/vendor/github.com/devfile/registry-support/index/generator/library/library.go
@@ -122,6 +122,10 @@ func GenerateIndexStruct(registryDirPath string, force bool) ([]schema.Schema, e
 		index = append(index, indexFromExtraDevfileEntries...)
 	}
 
+	index, err = SetLastModifiedValue(index, registryDirPath)
+	if err != nil {
+		return index, err
+	}
 	return index, nil
 }
 
@@ -703,6 +707,54 @@ func validateStackInfo(stackInfo schema.Schema, stackfolderDir string) []error {
 	}
 
 	return errors
+}
+
+// SetLastModifiedValue adds the last modified value to a pre-created index
+// The last modified dates are contained in a file named last_modified.json that is apart of the registry dir
+/* #nosec G304 -- lastModFile is produced from filepath.Join which cleans the input path */
+func SetLastModifiedValue(index []schema.Schema, registryDirPath string) ([]schema.Schema, error) {
+	lastModFile := filepath.Join(registryDirPath, "last_modified.json")
+	bytes, err := os.ReadFile(lastModFile)
+	if err != nil {
+		return index, err
+	}
+
+	var lastModifiedEntries schema.LastModifiedInfo
+	err = json.Unmarshal(bytes, &lastModifiedEntries)
+	if err != nil {
+		return index, err
+	}
+
+	lastModifiedEntriesMap := make(map[string]map[string]string)
+
+	for idx := range lastModifiedEntries.Stacks {
+		updateLastModifiedMap(lastModifiedEntriesMap, &lastModifiedEntries.Stacks[idx])
+	}
+
+	for idx := range lastModifiedEntries.Samples {
+		updateLastModifiedMap(lastModifiedEntriesMap, &lastModifiedEntries.Samples[idx])
+	}
+
+	for i := range index {
+		for j := range index[i].Versions {
+			updateSchemaLastModified(&index[i], j, lastModifiedEntriesMap[index[i].Name][index[i].Versions[j].Version])
+		}
+	}
+
+	return index, nil
+}
+
+func updateLastModifiedMap(m map[string]map[string]string, entry *schema.LastModifiedEntry) {
+	_, ok := m[entry.Name]
+	if !ok {
+		m[entry.Name] = make(map[string]string)
+	}
+
+	m[entry.Name][entry.Version] = entry.LastModified.Format("2006-01-02") //2006-01-02 is used to turn the date into YYYY-MM-DD format
+}
+
+func updateSchemaLastModified(s *schema.Schema, versionIndx int, lastModifiedDate string) {
+	s.Versions[versionIndx].LastModified = lastModifiedDate
 }
 
 // In checks if the value is in the array

--- a/index/server/vendor/github.com/devfile/registry-support/index/generator/schema/schema.go
+++ b/index/server/vendor/github.com/devfile/registry-support/index/generator/schema/schema.go
@@ -16,6 +16,8 @@
 package schema
 
 import (
+	"time"
+
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
@@ -264,4 +266,16 @@ type Version struct {
 	DeploymentScopes map[DeploymentScopeKind]bool `yaml:"deploymentScopes,omitempty" json:"deploymentScopes,omitempty"`
 	Resources        []string                     `yaml:"resources,omitempty" json:"resources,omitempty"`
 	StarterProjects  []string                     `yaml:"starterProjects,omitempty" json:"starterProjects,omitempty"`
+	LastModified     string                       `yaml:"lastModified,omitempty" json:"lastModified,omitempty"`
+}
+
+type LastModifiedEntry struct {
+	Name         string    `yaml:"name,omitempty" json:"name,omitempty"`
+	Version      string    `yaml:"version,omitempty" json:"version,omitempty"`
+	LastModified time.Time `yaml:"lastModified,omitempty" json:"lastModified,omitempty"`
+}
+
+type LastModifiedInfo struct {
+	Stacks  []LastModifiedEntry `yaml:"stacks,omitempty" json:"stacks,omitempty"`
+	Samples []LastModifiedEntry `yaml:"samples,omitempty" json:"samples,omitempty"`
 }

--- a/index/server/vendor/github.com/devfile/registry-support/index/generator/schema/schema.go
+++ b/index/server/vendor/github.com/devfile/registry-support/index/generator/schema/schema.go
@@ -40,6 +40,7 @@ Sample index file:
     ],
     "projectType": "maven",
     "language": "java",
+	"lastModified": "2024-05-13T12:32:02+02:00",
     "versions": [
       {
         "version": "1.1.0",
@@ -63,7 +64,8 @@ Sample index file:
         ],
         "starterProjects": [
           "springbootproject"
-        ]
+        ],
+		"lastModified": "2024-05-13T12:32:02+02:00"
       }
     ]
   },
@@ -81,6 +83,7 @@ Sample index file:
     ],
     "projectType": "quarkus",
     "language": "java",
+	"lastModified": "2024-04-29T17:08:43+03:00",
     "versions": [
       {
         "version": "1.1.0",
@@ -110,7 +113,8 @@ Sample index file:
         "starterProjects": [
           "community",
           "redhat-product"
-        ]
+        ],
+		"lastModified": "2024-04-29T17:08:43+03:00"
       }
     ]
   }
@@ -138,6 +142,7 @@ starterProjects: string[] - The project templates that can be used in the devfil
 git: *git - The information of remote repositories
 provider: string - The devfile provider information
 versions: []Version - The list of stack versions information
+lastModified: string - The date that a version of this stack/sample was last changed
 */
 
 // Schema is the index file schema
@@ -163,6 +168,7 @@ type Schema struct {
 	Provider          string                       `yaml:"provider,omitempty" json:"provider,omitempty"`
 	SupportUrl        string                       `yaml:"supportUrl,omitempty" json:"supportUrl,omitempty"`
 	Versions          []Version                    `yaml:"versions,omitempty" json:"versions,omitempty"`
+	LastModified      string                       `yaml:"lastModified,omitempty" json:"lastModified,omitempty"`
 }
 
 // DevfileType describes the type of devfile

--- a/tests/registry/last_modified.json
+++ b/tests/registry/last_modified.json
@@ -1,0 +1,57 @@
+{
+    "stacks": [
+      {
+        "name": "go",
+        "version": "1.0.2",
+        "lastModified": "2023-11-08T12:54:08+00:00"
+      },
+      {
+        "name": "go",
+        "version": "1.2.0",
+        "lastModified": "2023-04-08T11:51:08+00:00"
+      },
+      {
+        "name": "go",
+        "version": "2.0.0",
+        "lastModified": "2023-11-08T12:54:08+00:00"
+      },
+      {
+        "name": "go",
+        "version": "2.1.0",
+        "lastModified": "2023-04-08T11:51:08+00:00"
+      },
+      {
+        "name": "java-maven",
+        "version": "1.1.0",
+        "lastModified": "2024-05-13T12:32:02+02:00"
+      },
+      {
+        "name": "java-quarkus",
+        "version": "1.1.0",
+        "lastModified": "2024-04-29T17:08:43+03:00"
+      },
+      {
+        "name": "nodejs",
+        "version": "1.0.0",
+        "lastModified": "2024-04-29T12:16:30-04:00"
+      }
+    ],
+    "samples": [
+      {
+        "name": "nodejs-basic",
+        "version": "1.1.0",
+        "lastModified": "2024-06-05T15:26:11-04:00"
+      },
+      {
+        "name": "code-with-quarkus",
+        "version": "1.1.0",
+        "lastModified": "2024-04-29T11:45:48+01:00"
+      },
+      {
+        "name": "code-with-quarkus",
+        "version": "1.0.0",
+        "lastModified": "2024-02-15T11:45:48+01:00"
+      }
+    ]
+  }
+  


### PR DESCRIPTION
**Please specify the area for this PR**

**What does does this PR do / why we need it**:
This PR adds an additional filter parameter for stacks/samples on the `GET /v2index` endpoint.

Changes made include:
- Addition of `last_modified.json` and `lastModified` field to test data
- Updated unit tests for proper filtering based on the `lastModified` parameter
- Logic for creation of `index.json` to contain `lastModified` field based off of the `last_modified.json` created through registry build
- Update to generator schema to reflect new field
- Update to generator `index_main.json` to ensure last modified field is added correctly

**Which issue(s) this PR fixes**:

fixes https://github.com/devfile/api/issues/1327

**PR acceptance criteria**:

- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

Documentation (WIP)
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

**How to test changes / Special notes to the reviewer**:
FYI to reviewers: The linked issue has notes for `GET /index` and `GET /v2index`. The script that generates `last_modified.json` that was merged [here](https://github.com/devfile/registry/pull/429) currently creates this file based on the updated Schema used in `v2index` where there is a `Versions` field that contains `[]Version`. For the `/index` we would need to adjust the script to add the `lastModified` field to the entire stack as a whole and not just the individual stack versions.

- Go tests should pass for `index/generator` and `index/server`
- To test locally you can spin up the registry and perform the following:
    1. `GET /v2index?lastModified=2024-04-29` to see more than 1 stack that has this date
    2. `GET /v2index?lastModified=2024-04-29&name=<name>` to filter even further
    3. `GET /v2index/all`, `GET /v2index/stack` `GET/v2index/sample` to observe the new field added in the response as well