### PR TITLE
Add license to container images

### DIFF
--- a/index/server/Dockerfile
+++ b/index/server/Dockerfile
@@ -40,6 +40,10 @@ RUN set -x ; \
 # Modify the permissions on the necessary files to allow the container to properly run as a non-root UID
 RUN mkdir -p /www/data && chmod -R g+rwx /www/data
 
+# Add license
+RUN mkdir -p /licenses
+COPY LICENSE /licenses
+
 # disable http/2 on the index server by default
 ARG ENABLE_HTTP2=false
 ENV ENABLE_HTTP2=${ENABLE_HTTP2}

--- a/index/server/build-multi-arch.sh
+++ b/index/server/build-multi-arch.sh
@@ -30,6 +30,9 @@ PLATFORMS="linux/amd64,linux/arm64"
 # Generate OpenAPI endpoint and type definitions
 bash ${buildfolder}/codegen.sh
 
+# Copy license to include in image build
+cp ${buildfolder}/../../LICENSE ${buildfolder}/LICENSE
+
 if [ ${podman} == true ]; then
   echo "Executing with podman"
 
@@ -53,3 +56,6 @@ else
   docker buildx rm index-base-builder
 
 fi
+
+# Remove license from build directory
+rm ${buildfolder}/LICENSE

--- a/index/server/build.sh
+++ b/index/server/build.sh
@@ -41,6 +41,14 @@ echo "RUNNING: bash ${buildfolders}/codegen.sh"
 # Generate OpenAPI endpoint and type definitions
 bash ${buildfolder}/codegen.sh
 
+echo "RUNNING: cp ${buildfolder}/../../LICENSE ${buildfolder}/LICENSE"
+# Copy license to include in image build
+cp ${buildfolder}/../../LICENSE ${buildfolder}/LICENSE
+
 echo "RUNNING: docker build -t devfile-index-base:latest --platform ${arch} --build-arg ENABLE_HTTP2=${ENABLE_HTTP2} $buildfolder"
 # Build the index server
 docker build -t devfile-index-base:latest --platform "${arch}" --build-arg ENABLE_HTTP2=${ENABLE_HTTP2} $buildfolder
+
+echo "RUNNING: rm ${buildfolder}/LICENSE"
+# Remove license from build directory
+rm ${buildfolder}/LICENSE

--- a/oci-registry/Dockerfile
+++ b/oci-registry/Dockerfile
@@ -21,7 +21,13 @@ RUN microdnf update -y && rm -rf /var/cache/yum && microdnf install ca-certifica
 RUN set -x ; \
     adduser registry -u 1001 -G root && exit 0
 
+# Copy OCI registry binary from container image
 COPY --from=registry --chown=registry:0 /bin/registry /bin/registry
+
+# Add license
+RUN mkdir -p /licenses
+COPY LICENSE /licenses
+
 USER 1001
 EXPOSE 5000
 ENTRYPOINT ["registry"]

--- a/oci-registry/build-multi-arch.sh
+++ b/oci-registry/build-multi-arch.sh
@@ -48,6 +48,8 @@ function engine-handler {
     done
 }
 
+# Copy license to include in image build
+cp ${buildfolder}/../LICENSE ${buildfolder}/LICENSE
 
 if [ ${podman} == true ]; then
   echo "Executing with podman"
@@ -79,3 +81,6 @@ else
   docker manifest rm "$DEFAULT_MANIFEST"
 
 fi
+
+# Remove license from build directory
+rm ${buildfolder}/LICENSE

--- a/oci-registry/build.sh
+++ b/oci-registry/build.sh
@@ -32,4 +32,10 @@ fi
 # set podman alias if necessary
 . ${buildfolder}/../setenv.sh
 
+# Copy license to include in image build
+cp ${buildfolder}/../LICENSE ${buildfolder}/LICENSE
+
 docker build -t oci-registry:next --platform "${arch}" "$buildfolder"
+
+# Remove license from build directory
+rm ${buildfolder}/LICENSE

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -24,4 +24,8 @@ RUN cd /registry-test/registry-library && ./build.sh && cp /registry-test/regist
 # Build the test binary
 RUN /registry-test/build.sh
 
+# Add license
+RUN mkdir -p /licenses
+COPY LICENSE /licenses
+
 CMD /registry-test/devfile-registry-integration

--- a/tests/integration/docker-build.sh
+++ b/tests/integration/docker-build.sh
@@ -20,7 +20,13 @@
 # Get the registry-library
 cp -rf ../../registry-library ./
 
+# Copy license to include in image build
+cp ../../LICENSE LICENSE
+
 # Build the container image
 docker build -t devfile-registry-integration ./
+
+# Remove license from build directory
+rm LICENSE
 
 rm -rf ./registry-library/


### PR DESCRIPTION
# Description of Changes

Adds our source license for registry-support to all container images built here.

# Related Issue(s)

part of https://github.com/devfile/api/issues/1638

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->

### Tests
- [X] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

### Documentation
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

# Tests Performed

```sh
cat /licenses/LICENSE
```

Outputted the same contents of [LICENSE](https://github.com/devfile/registry-support/blob/a6907ada9c43f1f29df303dd5e19d8a64164f4f3/LICENSE).

# How To Test

Deploy images to OpenShift (or Kubernetes) using the helm chart and use the console under the containers to check if the licenses are properly added:

```sh
cat /licenses/LICENSE
```

Should output the same contents of [LICENSE](https://github.com/devfile/registry-support/blob/a6907ada9c43f1f29df303dd5e19d8a64164f4f3/LICENSE).
