### PR TITLE
fix: Adjust renovate schedules for wider time windows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,9 +9,9 @@
     "enabledManagers": ["tekton"],
     "packageRules": [
         {
-            "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (9 PM - 12 AM)",
+            "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (7 PM - 2 AM)",
             "matchManagers": ["tekton"],
-            "schedule": ["* 21-23 * * 2,4"]
+            "schedule": ["* 19-23,0-2 * * 2,4"]
         }
     ],
     "prHourlyLimit": 20,


### PR DESCRIPTION
# Description of Changes

Adjust the time windows for renovate PRs to be between 7pm-2am EST to cover more of the Konflux mintmaker renovate run schedule.

# Related Issue(s)

https://github.com/devfile/api/issues/1716

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->

### Tests
- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

### Documentation
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
