### PR TITLE
fix(wait-for-konflux): failures due to improper variable references

### DIFF
--- a/.github/workflows/includes/wait-for-check-start.yaml
+++ b/.github/workflows/includes/wait-for-check-start.yaml
@@ -42,7 +42,7 @@ jobs:
     steps:
       - name: Wait for ${{ inputs.check-name }} check to exist
         env:
-          GH_TOKEN: ${{ inputs.repo-token }}
+          GH_TOKEN: ${{ secrets.repo-token }}
           WAIT_TIMEOUT: ${{ inputs.wait-timeout }}
           WAIT_INTERVAL: ${{ inputs.wait-interval }}
           REPO: ${{ inputs.repository }}

--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -53,6 +53,7 @@ jobs:
       check-name: Red Hat Konflux / devfile-registry-base-main-on-push
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
+    secrets:
       repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   konfluxBuildWait:
@@ -73,6 +74,7 @@ jobs:
       check-name: Red Hat Konflux / devfile-registry-main-enterprise-contract / devfile-registry-base-main
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
+    secrets:
       repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   konfluxECWait:

--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -50,7 +50,7 @@ jobs:
     needs: indexServerBuild
     uses: ./.github/workflows/includes/wait-for-check-start.yaml
     with:
-      check-name: Red Hat Konflux / devfile-registry-base-main-on-push 
+      check-name: Red Hat Konflux / devfile-registry-base-main-on-push
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -63,7 +63,7 @@ jobs:
         uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.ref }}
-          check-name: Red Hat Konflux / devfile-registry-base-main-on-push 
+          check-name: Red Hat Konflux / devfile-registry-base-main-on-push
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   waitForKonfluxECStart:

--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -21,10 +21,6 @@ on:
   repository_dispatch:
     types: [build]
 
-env:
-  INDEX_BASE_KONFLUX_BUILD_CHECK: Red Hat Konflux / devfile-registry-base-main-on-push 
-  INDEX_BASE_KONFLUX_EC_CHECK: Red Hat Konflux / devfile-registry-main-enterprise-contract / devfile-registry-base-main
-
 jobs:
   indexServerBuild:
     runs-on: ubuntu-latest
@@ -54,7 +50,7 @@ jobs:
     needs: indexServerBuild
     uses: ./.github/workflows/includes/wait-for-check-start.yaml
     with:
-      check-name: ${{ env.INDEX_BASE_KONFLUX_BUILD_CHECK }}
+      check-name: Red Hat Konflux / devfile-registry-base-main-on-push 
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -63,18 +59,18 @@ jobs:
     needs: waitForKonfluxBuildStart
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for ${{ env.INDEX_BASE_KONFLUX_BUILD_CHECK }} tasks to finish
+      - name: Wait for Red Hat Konflux / devfile-registry-base-main-on-push tasks to finish
         uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.ref }}
-          check-name: ${{ env.INDEX_BASE_KONFLUX_BUILD_CHECK }}
+          check-name: Red Hat Konflux / devfile-registry-base-main-on-push 
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   waitForKonfluxECStart:
     needs: konfluxBuildWait
     uses: ./.github/workflows/includes/wait-for-check-start.yaml
     with:
-      check-name: ${{ env.INDEX_BASE_KONFLUX_EC_CHECK }}
+      check-name: Red Hat Konflux / devfile-registry-main-enterprise-contract / devfile-registry-base-main
       repository: ${{ github.repository }}
       ref: ${{ github.ref }}
       repo-token: ${{ secrets.GITHUB_TOKEN }}
@@ -83,11 +79,11 @@ jobs:
     needs: waitForKonfluxECStart
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for ${{ env.INDEX_BASE_KONFLUX_EC_CHECK }} checks to finish
+      - name: Wait for Red Hat Konflux / devfile-registry-main-enterprise-contract / devfile-registry-base-main checks to finish
         uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
           ref: ${{ github.ref }}
-          check-name: ${{ env.INDEX_BASE_KONFLUX_EC_CHECK }}
+          check-name: Red Hat Konflux / devfile-registry-main-enterprise-contract / devfile-registry-base-main
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
   dispatchCommunity:


### PR DESCRIPTION
# Description of Changes
_Summarize the changes you made as part of this pull request._

https://github.com/devfile/registry-support/pull/345 introduces workflow syntax errors due to improper use of environment variables in specific places, causing the build trigger for the community registry to fail. This PR replaces all usages of these environment variables with the constant string values.

# Related Issue(s)
_Link the GitHub/GitLab/JIRA issues that are related to this PR._

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->

### Tests
- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

### Documentation
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow configuration to streamline build check procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->