### PR TITLE
chore: update Konflux tekton patch schedule to weekends

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,13 +16,12 @@
     ],
     "packageRules": [
         {
-            "description": "Schedule Konflux tekton task updates Tuesday and Thursday nights (7 PM - 2 AM)",
+            "description": "Schedule Konflux tekton task updates Saturdays after 5 AM",
             "matchManagers": [
                 "tekton"
             ],
             "schedule": [
-                "* 19-23 * * 2,4",
-                "* 0-2 * * 3,5"
+                "* 5-23 * * 6"
             ]
         },
         {


### PR DESCRIPTION
# Description of Changes

The [Konflux Documentation](https://konflux-ci.dev/docs/mintmaker/user/#scheduling) states that the Konflux patching only happens on Saturdays after 5AM. Given this seems to be enforced, we'll need to update our Konflux patching schedule across our Devfile Registry repositories to run MintMaker Renovate to patch Konflux on that schedule.

# Related Issue(s)

https://github.com/devfile/api/issues/1779

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->

### Tests
- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

### Documentation
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._
