### PR TITLE
fix(wait-for-konflux): add allowed-conclusions to include 'neutral' state

### DIFF
--- a/.github/workflows/pushimage-next.yaml
+++ b/.github/workflows/pushimage-next.yaml
@@ -84,6 +84,7 @@ jobs:
       - name: Wait for Red Hat Konflux / devfile-registry-main-enterprise-contract / devfile-registry-base-main checks to finish
         uses: lewagon/wait-on-check-action@74049309dfeff245fe8009a0137eacf28136cb3c # v1.5.0
         with:
+          allowed-conclusions: success,skipped,neutral
           ref: ${{ github.ref }}
           check-name: Red Hat Konflux / devfile-registry-main-enterprise-contract / devfile-registry-base-main
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description of Changes

Fixes currently failing `konfluxECWait` job when leading up to staging promotion dispatch to restore promotion triggers when changes are introduced to registry-support modules.

# Related Issue(s)

fixes https://github.com/devfile/api/issues/1772

# Acceptance Criteria
<!-- _Check the relevant boxes below_ -->

### Tests
- [ ] Test Coverage 
    - Are your changes sufficiently tested, and are any applicable test cases added or updated to cover your changes?

### Documentation
- [ ] Does the [REST API doc](../index/server/registry-REST-API.adoc) need to be updated with your changes?
- [ ] Does the [registry library doc](../registry-library/README.md) need to be updated with your changes?

# Tests Performed
_Explain what tests you personally ran to ensure the changes are functioning as expected._

# How To Test
_Instructions for the reviewer on how to test your changes._

# Notes To Reviewer
_Any notes you would like to include for the reviewer._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated workflow handling by allowing successful, skipped, or neutral check results to proceed without unnecessary delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->